### PR TITLE
feat(KONFLUX-2067): retrieve ocp version from labels

### DIFF
--- a/tasks/managed/filter-published-fbc-images/README.md
+++ b/tasks/managed/filter-published-fbc-images/README.md
@@ -3,7 +3,15 @@
 Filters snapshot to remove already-released FBC fragments by querying Pyxis index images.
 Queries for index images and checks if fragments are present in their bundles/related_images fields.
 Components already published are filtered out to prevent EC validation failures.
-Additionally, extracts and attaches ocpVersion field to each component for downstream tasks.
+Extracts and attaches ocpVersion field to each component for downstream tasks.
+OCP version resolution order:
+  1. com.redhat.fbc.openshift.version label - expects a non-empty JSON array.
+     Currently only the first OCP version from the array is used.
+     Recommended for binaryless fragments. Works for pre-GA OCP versions.
+     Enables shipping a single FBC to multiple OCP catalogs. Allowed versions for this label are >=v4.15
+     Dockerfile example: LABEL com.redhat.fbc.openshift.version='["v4.18","v4.21"]'
+  2. org.opencontainers.image.base.name annotation - Legacy fallback.
+     Requires OCP-version-specific operator-registry image. Cannot target pre-GA versions.
 
 ## Parameters
 

--- a/tasks/managed/filter-published-fbc-images/filter-published-fbc-images.yaml
+++ b/tasks/managed/filter-published-fbc-images/filter-published-fbc-images.yaml
@@ -11,7 +11,15 @@ spec:
     Filters snapshot to remove already-released FBC fragments by querying Pyxis index images.
     Queries for index images and checks if fragments are present in their bundles/related_images fields.
     Components already published are filtered out to prevent EC validation failures.
-    Additionally, extracts and attaches ocpVersion field to each component for downstream tasks.
+    Extracts and attaches ocpVersion field to each component for downstream tasks.
+    OCP version resolution order:
+      1. com.redhat.fbc.openshift.version label - expects a non-empty JSON array.
+         Currently only the first OCP version from the array is used.
+         Recommended for binaryless fragments. Works for pre-GA OCP versions.
+         Enables shipping a single FBC to multiple OCP catalogs. Allowed versions for this label are >=v4.15
+         Dockerfile example: LABEL com.redhat.fbc.openshift.version='["v4.18","v4.21"]'
+      2. org.opencontainers.image.base.name annotation - Legacy fallback.
+         Requires OCP-version-specific operator-registry image. Cannot target pre-GA versions.
   params:
     - name: snapshotPath
       type: string
@@ -174,19 +182,55 @@ spec:
           component=$(jq -c ".components[$i]" "${SNAPSHOT_FILE}")
           component_name=$(jq -r '.name' <<< "$component")
           container_image=$(jq -r '.containerImage' <<< "$component")
+          ocp_version=""
 
           echo "  Component $((i+1))/${component_count}: ${component_name}"
-          echo "    → Extracting OCP version from base image..."
 
-          # Extract OCP version from org.opencontainers.image.base.name annotation
-          raw_image_metadata=$(skopeo inspect --retry-times 3 --raw "docker://${container_image}")
-          media_type=$(jq -r .mediaType <<< "${raw_image_metadata}")
-          ocp_version=$(jq -r '.annotations."org.opencontainers.image.base.name"' <<< "${raw_image_metadata}" \
-            | cut -d: -f2 | sed "s/[\"']//g")
+          echo "    → Extracting OCP version from \"com.redhat.fbc.openshift.version\" label"
+          # Extract OCP version from com.redhat.fbc.openshift.version
+          image_metadata=$(skopeo inspect --retry-times 3 --no-tags "docker://${container_image}")
 
-          # Handle multiplatform images
-          if [[ "$media_type" == "application/vnd.oci.image.index.v1+json" ]] || \
-             [[ "$media_type" == "application/vnd.docker.distribution.manifest.list.v2+json" ]]; then
+          # Returns the label value if present, or 'MISSING' as a sentinel.
+          # Using has() instead of // to distinguish between a missing label and a label with a null value.
+          label_value=$(jq -r '
+            if .Labels | has("com.redhat.fbc.openshift.version")
+            then .Labels["com.redhat.fbc.openshift.version"]
+            else "MISSING"
+            end' <<< "$image_metadata")
+
+          # Label is present
+          if [[ "$label_value" != "MISSING" ]]; then
+
+            # Label value must be a non-empty JSON array (catches null, empty, empty array, non-array values)
+            if ! jq -e 'type == "array" and length > 0' <<< "$label_value" > /dev/null 2>&1; then
+              echo "    ❌ ERROR: \"com.redhat.fbc.openshift.version\" label has" \
+                   "invalid value '${label_value}' for ${container_image}," \
+                   "array with ocp_versions e.g. [\"v4.21\"] is expected."
+              exit 1
+            fi
+
+            # The release pipeline doesn't support multiple OCP versions for a single FBC fragment yet. 
+            # This will be removed once that support is added in CLOUDDST-32151
+            ocp_version=$(jq -r 'first' <<< "$label_value")
+
+            # There is more than one ocp version present in the label
+            if [[ $(jq 'length' <<< "$label_value") -gt 1 ]]; then
+              echo "    INFO: Multiple versions found in label (${label_value}). Selecting first: ${ocp_version}"
+            fi
+            echo "    → OCP version extracted from label \"com.redhat.fbc.openshift.version\": ${ocp_version}"
+
+          # Fallback: label was missing, extract from annotation
+          else
+            echo "    → Extracting OCP version from base image..."
+            # Extract OCP version from org.opencontainers.image.base.name annotation
+            raw_image_metadata=$(skopeo inspect --retry-times 3 --raw "docker://${container_image}")
+            media_type=$(jq -r .mediaType <<< "${raw_image_metadata}")
+            ocp_version=$(jq -r '.annotations."org.opencontainers.image.base.name"' <<< "${raw_image_metadata}" \
+              | cut -d: -f2 | sed "s/[\"']//g")
+
+            # Handle multiplatform images
+            if [[ "$media_type" == "application/vnd.oci.image.index.v1+json" ]] || \
+               [[ "$media_type" == "application/vnd.docker.distribution.manifest.list.v2+json" ]]; then
               echo "    INFO: Multiplatform image detected, extracting manifest"
               arch_json=$(get-image-architectures "${container_image}")
               manifest_image_sha="$(jq -rs 'map(.digest)[0]'  <<< "$arch_json")"
@@ -194,15 +238,17 @@ spec:
 
               ocp_version=$(skopeo inspect --retry-times 3 --raw "docker://${single_arch_fragment}" \
                | jq -r '.annotations."org.opencontainers.image.base.name"' | cut -d: -f2 | sed "s/[\"']//g")
+            fi
+
+            echo "    → OCP version extracted from annotation: ${ocp_version}"
           fi
 
           if [ -z "$ocp_version" ] || [ "$ocp_version" = "null" ]; then
             echo "    ❌ ERROR: Could not extract OCP version from ${container_image}"
+            echo "       Label \"com.redhat.fbc.openshift.version\" not found"
             echo "       Annotation 'org.opencontainers.image.base.name' not found"
             exit 1
           fi
-
-          echo "    → OCP version extracted from annotation: ${ocp_version}"
 
           # Add 'v' prefix if not already present
           if [[ ! "$ocp_version" =~ ^v ]]; then

--- a/tasks/managed/filter-published-fbc-images/tests/mocks.sh
+++ b/tasks/managed/filter-published-fbc-images/tests/mocks.sh
@@ -53,6 +53,22 @@ skopeo() {
       ocp_version="4.15"
     fi
 
+    # Determine com.redhat.fbc.openshift.version label based on digest pattern
+    local fbc_label=""
+    if [[ "$image" == *"@sha256:labelnull"* ]]; then
+      fbc_label='"com.redhat.fbc.openshift.version": null,'
+    elif [[ "$image" == *"@sha256:labelempty"* ]]; then
+      fbc_label='"com.redhat.fbc.openshift.version": "[]",'
+    elif [[ "$image" == *"@sha256:labelmulti"* ]]; then
+      fbc_label='"com.redhat.fbc.openshift.version": "[\"v4.20\",\"v4.21\"]",'
+    elif [[ "$image" == *"@sha256:labelvalid"* ]]; then
+      fbc_label='"com.redhat.fbc.openshift.version": "[\"v4.21\"]",'
+    elif [[ "$image" == *"@sha256:labelstring"* ]]; then
+      fbc_label='"com.redhat.fbc.openshift.version": "v4.21",'
+    elif [[ "$image" == *"@sha256:nolabel"* ]]; then
+      fbc_label=""
+    fi
+
     echo "Mock skopeo returning OCP version: $ocp_version for image: $image" >&2
 
     # Return mock skopeo inspect JSON with OCP version in base image annotation
@@ -66,6 +82,7 @@ skopeo() {
   "Created": "2024-01-01T00:00:00Z",
   "DockerVersion": "",
   "Labels": {
+    $fbc_label
     "org.opencontainers.image.base.name": "registry.access.redhat.com/ubi9/ubi:$ocp_version"
   },
   "Architecture": "amd64",
@@ -338,12 +355,11 @@ if [[ "$*" == *"inspect"* ]]; then
     # The label should be: '["v4.17","v4.18"]'
     ocp_version="4.17"  # Base image shows v4.17, but component supports both
   elif [[ "$image" == *"@sha256:invalidocp"* ]]; then
-    # Invalid OCP version format for testing validation (three parts instead of two)
     ocp_version="4.14.1"
   fi
-  
+
   echo "  → Returning OCP version: $ocp_version" >&2
-  
+
   cat <<JSONEOF
 {
   "Name": "$image",

--- a/tasks/managed/filter-published-fbc-images/tests/test-filter-published-fbc-label-empty-array.yaml
+++ b/tasks/managed/filter-published-fbc-images/tests/test-filter-published-fbc-label-empty-array.yaml
@@ -1,0 +1,135 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-filter-published-fbc-label-empty-array
+  annotations:
+    test/assert-task-failure: "run-filter"
+spec:
+  description: |
+    Test: Verify that filter-published-fbc-images fails when the
+    com.redhat.fbc.openshift.version label exists but has an empty array value "[]".
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: >-
+        Expiration date for the trusted artifacts created in the OCI repository.
+        An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: >-
+        Flag to enable debug logging in trusted artifacts.
+        Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      params:
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: ociStorage
+            type: string
+          - name: orasOptions
+            type: string
+          - name: dataDir
+            type: string
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: ORAS_OPTIONS
+              value: $(params.orasOptions)
+        steps:
+          - name: create-test-data
+            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+
+              # Component with sha256:labelempty digest triggers mock to return
+              # com.redhat.fbc.openshift.version: "[]"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << 'EOF'
+              {
+                "application": "test-app",
+                "components": [
+                  {
+                    "name": "comp-label-empty",
+                    "containerImage": "quay.io/test/comp1@sha256:labelempty001"
+                  }
+                ]
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << 'EOF'
+              {
+                "pyxis": {
+                  "secret": "pyxis",
+                  "server": "production"
+                },
+                "fbc": {
+                  "targetIndex": "quay.io/redhat-pending/catalog:v4.15",
+                  "publishingCredentials": "test-publishing-creds"
+                }
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-filter
+      runAfter:
+        - setup
+      taskRef:
+        name: filter-published-fbc-images
+      params:
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot.json"
+        - name: dataPath
+          value: "$(context.pipelineRun.uid)/data.json"
+        - name: pyxisSecret
+          value: "pyxis"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"

--- a/tasks/managed/filter-published-fbc-images/tests/test-filter-published-fbc-label-not-array.yaml
+++ b/tasks/managed/filter-published-fbc-images/tests/test-filter-published-fbc-label-not-array.yaml
@@ -1,0 +1,136 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-filter-published-fbc-label-not-array
+  annotations:
+    test/assert-task-failure: "run-filter"
+spec:
+  description: |
+    Test: Verify that filter-published-fbc-images fails when the
+    com.redhat.fbc.openshift.version label exists but is a plain string "v4.21"
+    instead of the expected array format "[\"v4.21\"]".
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: >-
+        Expiration date for the trusted artifacts created in the OCI repository.
+        An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: >-
+        Flag to enable debug logging in trusted artifacts.
+        Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      params:
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: ociStorage
+            type: string
+          - name: orasOptions
+            type: string
+          - name: dataDir
+            type: string
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: ORAS_OPTIONS
+              value: $(params.orasOptions)
+        steps:
+          - name: create-test-data
+            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+
+              # Component with sha256:labelstring digest triggers mock to return
+              # com.redhat.fbc.openshift.version: "v4.21" (plain string, not array)
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << 'EOF'
+              {
+                "application": "test-app",
+                "components": [
+                  {
+                    "name": "comp-label-string",
+                    "containerImage": "quay.io/test/comp1@sha256:labelstring001"
+                  }
+                ]
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << 'EOF'
+              {
+                "pyxis": {
+                  "secret": "pyxis",
+                  "server": "production"
+                },
+                "fbc": {
+                  "targetIndex": "quay.io/redhat-pending/catalog:v4.15",
+                  "publishingCredentials": "test-publishing-creds"
+                }
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-filter
+      runAfter:
+        - setup
+      taskRef:
+        name: filter-published-fbc-images
+      params:
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot.json"
+        - name: dataPath
+          value: "$(context.pipelineRun.uid)/data.json"
+        - name: pyxisSecret
+          value: "pyxis"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"

--- a/tasks/managed/filter-published-fbc-images/tests/test-filter-published-fbc-label-null.yaml
+++ b/tasks/managed/filter-published-fbc-images/tests/test-filter-published-fbc-label-null.yaml
@@ -1,0 +1,135 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-filter-published-fbc-label-null
+  annotations:
+    test/assert-task-failure: "run-filter"
+spec:
+  description: |
+    Test: Verify that filter-published-fbc-images fails when the
+    com.redhat.fbc.openshift.version label exists but has a null value.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: >-
+        Expiration date for the trusted artifacts created in the OCI repository.
+        An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: >-
+        Flag to enable debug logging in trusted artifacts.
+        Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      params:
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: ociStorage
+            type: string
+          - name: orasOptions
+            type: string
+          - name: dataDir
+            type: string
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: ORAS_OPTIONS
+              value: $(params.orasOptions)
+        steps:
+          - name: create-test-data
+            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+
+              # Component with sha256:labelnull digest triggers mock to return
+              # com.redhat.fbc.openshift.version: null
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << 'EOF'
+              {
+                "application": "test-app",
+                "components": [
+                  {
+                    "name": "comp-label-null",
+                    "containerImage": "quay.io/test/comp1@sha256:labelnull001"
+                  }
+                ]
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << 'EOF'
+              {
+                "pyxis": {
+                  "secret": "pyxis",
+                  "server": "production"
+                },
+                "fbc": {
+                  "targetIndex": "quay.io/redhat-pending/catalog:v4.15",
+                  "publishingCredentials": "test-publishing-creds"
+                }
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-filter
+      runAfter:
+        - setup
+      taskRef:
+        name: filter-published-fbc-images
+      params:
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot.json"
+        - name: dataPath
+          value: "$(context.pipelineRun.uid)/data.json"
+        - name: pyxisSecret
+          value: "pyxis"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"

--- a/tasks/managed/filter-published-fbc-images/tests/test-filter-published-fbc-label-valid.yaml
+++ b/tasks/managed/filter-published-fbc-images/tests/test-filter-published-fbc-label-valid.yaml
@@ -1,0 +1,241 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-filter-published-fbc-label-valid
+spec:
+  description: |
+    Test: Verify OCP version extraction from com.redhat.fbc.openshift.version label.
+    Covers three scenarios:
+      - Label with single valid value ("[\"v4.21\"]")
+      - Label with multiple values ("[\"v4.20\",\"v4.21\"]") - picks first
+      - Label missing - falls back to org.opencontainers.image.base.name annotation
+    It is best, if each component has different ocp_version,
+    that way we also test that the loop works correctly
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: >-
+        Expiration date for the trusted artifacts created in the OCI repository.
+        An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: >-
+        Flag to enable debug logging in trusted artifacts.
+        Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      params:
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: ociStorage
+            type: string
+          - name: orasOptions
+            type: string
+          - name: dataDir
+            type: string
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: ORAS_OPTIONS
+              value: $(params.orasOptions)
+        steps:
+          - name: create-test-data
+            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+
+              # Create test snapshot with 3 components testing label extraction:
+              # - comp-label-valid (sha256:labelvalid001): label "[\"v4.21\"]" -> ocpVersion v4.21
+              # - comp-label-multi (sha256:labelmulti001): label "[\"v4.20\",\"v4.21\"]" -> picks first: v4.20
+              # - comp-no-label (sha256:nolabel001): no label -> fallback to annotation: v4.15
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << 'EOF'
+              {
+                "application": "test-app-label",
+                "components": [
+                  {
+                    "name": "comp-label-valid",
+                    "containerImage": "quay.io/test/comp1@sha256:labelvalid001"
+                  },
+                  {
+                    "name": "comp-label-multi",
+                    "containerImage": "quay.io/test/comp2@sha256:labelmulti001"
+                  },
+                  {
+                    "name": "comp-no-label",
+                    "containerImage": "quay.io/test/comp3@sha256:nolabel001"
+                  }
+                ]
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << 'EOF'
+              {
+                "pyxis": {
+                  "secret": "pyxis",
+                  "server": "production"
+                },
+                "fbc": {
+                  "targetIndex": "quay.io/redhat-pending/catalog:{{ OCP_VERSION }}",
+                  "publishingCredentials": "test-publishing-creds"
+                }
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-filter
+      runAfter:
+        - setup
+      taskRef:
+        name: filter-published-fbc-images
+      params:
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot.json"
+        - name: dataPath
+          value: "$(context.pipelineRun.uid)/data.json"
+        - name: pyxisSecret
+          value: "pyxis"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+    - name: verify-results
+      runAfter:
+        - run-filter
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-filter.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: orasOptions
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: ORAS_OPTIONS
+              value: $(params.orasOptions)
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-filtered-snapshot
+            image: quay.io/konflux-ci/release-service-utils:cee1fd0191e750b0736d8197701d91ce2f308e03
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              FILTERED_SNAPSHOT="$(params.dataDir)/filtered-snapshot.json"
+
+              if [ ! -f "${FILTERED_SNAPSHOT}" ]; then
+                echo "ERROR: Filtered snapshot not found at ${FILTERED_SNAPSHOT}"
+                exit 1
+              fi
+
+              echo "Filtered snapshot contents:"
+              jq . "${FILTERED_SNAPSHOT}"
+
+              COUNT=$(jq '.components | length' "${FILTERED_SNAPSHOT}")
+              echo "Component count: ${COUNT}"
+
+              # Expected: 3 components (none published, all kept)
+              if [ "${COUNT}" -ne 3 ]; then
+                echo "ERROR: Expected 3 components, got ${COUNT}"
+                exit 1
+              fi
+
+              # Verify comp-label-valid has ocpVersion from label "com.redhat.fbc.openshift.version"
+              # label com.redhat.fbc.openshift.version is "[\"v4.21\"]", annotation is 4.15
+              ocp_valid=$(jq -c '.components[] | select(.name == "comp-label-valid") | .ocpVersion //empty' \
+                  "${FILTERED_SNAPSHOT}")
+              if [ "${ocp_valid}" != '["v4.21"]' ]; then
+                echo "ERROR: comp-label-valid ocpVersion expected [\"v4.21\"], got '${ocp_valid}'"
+                exit 1
+              fi
+              echo "comp-label-valid ocpVersion: ${ocp_valid} (from label)"
+
+              # Verify comp-label-multi has ocpVersion from first value of multi-value label
+              # label com.redhat.fbc.openshift.version is "[\"v4.20\",\"v4.21\"]", annotation is 4.15
+              ocp_multi=$(jq -c '.components[] | select(.name == "comp-label-multi") | .ocpVersion //empty' \
+                  "${FILTERED_SNAPSHOT}")
+              if [ "${ocp_multi}" != '["v4.20"]' ]; then
+                echo "ERROR: comp-label-multi ocpVersion expected [\"v4.20\"], got '${ocp_multi}'"
+                exit 1
+              fi
+              echo "comp-label-multi ocpVersion: ${ocp_multi} (first of multi-value label)"
+
+              # Verify comp-no-label has ocpVersion from annotation fallback
+              # label not present, annotation = 4.15
+              ocp_nolabel=$(jq -c '.components[] | select(.name == "comp-no-label") | .ocpVersion //empty' \
+                  "${FILTERED_SNAPSHOT}")
+              if [ "${ocp_nolabel}" != '["v4.15"]' ]; then
+                echo "ERROR: comp-no-label ocpVersion expected [\"v4.15\"], got '${ocp_nolabel}'"
+                exit 1
+              fi
+              echo "comp-no-label ocpVersion: ${ocp_nolabel} (from annotation fallback)"
+
+              echo "Test passed: All label extraction paths verified"


### PR DESCRIPTION
## Describe your changes

This change adds support for extracting the OCP version from the com.redhat.fbc.openshift.version Dockerfile label. If the label is present, its value is used as the OCP version. If the label is not present, we fall back to the existing org.opencontainers.image.base.name annotation. When multiple OCP versions are specified in the label, the first one is used.

**Expected label format in the Dockerfile:**                                                                                                                                                                                                       
`LABEL com.redhat.fbc.openshift.version='["v4.18","v4.21"]'`


## Relevant Jira
[KONFLUX-2067](https://redhat.atlassian.net/browse/KONFLUX-2067), [CLOUDDST-31638](https://redhat.atlassian.net/browse/CLOUDDST-31638)


Assisted-By: Claude, Gemini

[CLOUDDST-31638]: https://redhat.atlassian.net/browse/CLOUDDST-31638?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[KONFLUX-2067]: https://redhat.atlassian.net/browse/KONFLUX-2067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ