### PR TITLE
fix: bump release-service-utils image for dual-compression dedup

### DIFF
--- a/tasks/managed/create-pyxis-image/create-pyxis-image.yaml
+++ b/tasks/managed/create-pyxis-image/create-pyxis-image.yaml
@@ -159,7 +159,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: create-pyxis-image
-      image: quay.io/konflux-ci/release-service-utils@sha256:c81b122f6274b2bc437a09ecef657af7ccc8f99887e29278f62c424ac911a2f3
+      image: quay.io/konflux-ci/release-service-utils@sha256:95f602cfb374c4798e4fbf3d298efe0218ac55308446d3f70f5df8add9675e83
       computeResources:
         limits:
           memory: 3Gi

--- a/tasks/managed/create-pyxis-image/tests/mocks.sh
+++ b/tasks/managed/create-pyxis-image/tests/mocks.sh
@@ -84,6 +84,10 @@ function get-image-architectures() {
   if [[ "$*" =~ registry.io/multi-arch-image.?@sha256:mydigest.? ]]; then
     echo '{"platform":{"architecture": "amd64", "os": "linux"}, "digest": "abcdefg"}'
     echo '{"platform":{"architecture": "ppc64le", "os": "linux"}, "digest": "deadbeef"}'
+  elif [[ "$*" =~ registry.io/dual-compression-image.?@sha256:mydigest.? ]]; then
+    # Dual-compression index: get-image-architectures dedups to the gzip entry per arch
+    echo '{"platform":{"architecture": "amd64", "os": "linux"}, "digest": "abcdefg"}'
+    echo '{"platform":{"architecture": "ppc64le", "os": "linux"}, "digest": "deadbeef"}'
   elif [[ "$1" = registry.io/fail-get-image-architectures@sha256:mydigest ]]; then
     echo "Simulating get-image-architectures failure" >&2
     return 1

--- a/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-dual-compression.yaml
+++ b/tasks/managed/create-pyxis-image/tests/test-create-pyxis-image-dual-compression.yaml
@@ -1,0 +1,195 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-create-pyxis-image-dual-compression
+spec:
+  description: |
+    Run the create-pyxis-image task with a dual-compression image index that
+    contains both gzip and zstd:chunked manifests per architecture.
+    get-image-architectures deduplicates to the gzip entry per architecture,
+    so the task should create only 2 Pyxis image entries (not 4).
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils@sha256:c81b122f6274b2bc437a09ecef657af7ccc8f99887e29278f62c424ac911a2f3
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)"/mapped_snapshot.json << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp",
+                    "containerImage": "source@sha256:mydigest",
+                    "repositories": [
+                      {
+                        "url": "registry.io/dual-compression-image",
+                        "tags": [
+                          "testtag"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/mydata.json" << EOF
+              {
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: create-pyxis-image
+      params:
+        - name: pyxisSecret
+          value: test-create-pyxis-image-cert
+        - name: server
+          value: stage
+        - name: snapshotPath
+          value: $(context.pipelineRun.uid)/mapped_snapshot.json
+        - name: dataPath
+          value: $(context.pipelineRun.uid)/mydata.json
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: pyxisDataPath
+          value: $(tasks.run-task.results.pyxisDataPath)
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: pyxisDataPath
+            type: string
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils@sha256:c81b122f6274b2bc437a09ecef657af7ccc8f99887e29278f62c424ac911a2f3
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              # The dedup filter should reduce 4 entries (2 arches x 2 compressions)
+              # to 2 entries (1 per arch, gzip only). create_container_image
+              # should be called 2 times, not 4.
+              if [ "$(wc -l < \
+                "$(params.dataDir)/mock_create_container_image.txt")" != 2 ]; then
+                echo Error: create_container_image was expected to be called 2 times. Actual calls:
+                cat "$(params.dataDir)/mock_create_container_image.txt"
+                exit 1
+              fi
+
+              # Verify the correct arch and digest are in the pyxis data
+              jq -e '.components[0].pyxisImages[0] | ( .arch == "amd64" ) and ( .imageId == "0001" )
+                and ( .os == "linux" )' "$(params.dataDir)/$(params.pyxisDataPath)"
+
+              jq -e '.components[0].pyxisImages[1] | ( .arch == "ppc64le" ) and ( .imageId == "0002" )
+                and ( .os == "linux" )' "$(params.dataDir)/$(params.pyxisDataPath)"
+
+              # Verify skopeo was called 1 time (for the index inspect)
+              if [ "$(wc -l < "$(params.dataDir)/mock_skopeo.txt")" != 1 ]; then
+                echo Error: skopeo was expected to be called 1 time. Actual calls:
+                cat "$(params.dataDir)/mock_skopeo.txt"
+                exit 1
+              fi
+
+              [ "$(head -n 1 < "$(params.dataDir)/mock_skopeo.txt")" \
+                = "inspect --retry-times 3 --raw docker://registry.io/dual-compression-image@sha256:mydigest" ]
+
+      runAfter:
+        - run-task

--- a/tasks/managed/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/filter-already-released-advisory-images.yaml
@@ -145,7 +145,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: run-script
-      image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+      image: quay.io/konflux-ci/release-service-utils@sha256:95f602cfb374c4798e4fbf3d298efe0218ac55308446d3f70f5df8add9675e83
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/managed/filter-already-released-advisory-images/tests/mocks.sh
+++ b/tasks/managed/filter-already-released-advisory-images/tests/mocks.sh
@@ -13,6 +13,9 @@ function get-image-architectures() {
     echo '{"platform":{"architecture":"amd64","os":"linux"},"digest":"sha256:amd64digest_abc123"}'
   elif [[ "$image" == *"sha256:def456"* ]]; then
     echo '{"platform":{"architecture":"amd64","os":"linux"},"digest":"sha256:amd64digest_def456"}'
+  elif [[ "$image" == *"sha256:dualdigest"* ]]; then
+    # Dual-compression index: get-image-architectures dedups to the gzip entry per arch
+    echo '{"platform":{"architecture":"amd64","os":"linux"},"digest":"sha256:amd64gzip"}'
   else
     # Default deterministic output
     echo '{"platform":{"architecture":"amd64","os":"linux"},"digest":"sha256:amd64digest_default"}'
@@ -23,7 +26,8 @@ function kubectl() {
   # The IR won't actually be acted upon, so mock it to return Success as the task wants
   if [[ "$*" == *"get internalrequest"*"-o=jsonpath={.status.results}"* ]]
   then
-    UNRELEASED=$(echo -n '["new-component", "multi-repo-component", "single-repo-component"]' | gzip -c | base64 -w 0)
+    # Include dual-compression-component in unreleased list for the dual test
+    UNRELEASED=$(echo -n '["new-component", "multi-repo-component", "single-repo-component", "dual-compression-component"]' | gzip -c | base64 -w 0)
     echo '{
       "result": "Success",
       "unreleased_components": "'"$UNRELEASED"'",

--- a/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-images-dual-compression.yaml
+++ b/tasks/managed/filter-already-released-advisory-images/tests/test-filter-already-released-advisory-images-dual-compression.yaml
@@ -1,0 +1,260 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-filter-already-released-advisory-images-dual-compression
+spec:
+  description: |
+    Run the filter-already-released-advisory-images task with a dual-compression
+    image index that contains both gzip and zstd:chunked manifests for amd64.
+    get-image-architectures deduplicates to the gzip entry, so the task should
+    create only 1 transformed component (not 2) using the gzip digest.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: ORAS_OPTIONS
+              value: "$(params.orasOptions)"
+            - name: DEBUG
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: create-inputs
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/results"
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_release_plan_admission.json" <<EOF
+              {
+                "apiVersion": "appstudio.redhat.com/v1alpha1",
+                "kind": "ReleasePlanAdmission",
+                "metadata": {
+                  "name": "test",
+                  "namespace": "default"
+                },
+                "spec": {
+                  "applications": ["app"],
+                  "origin": "dev"
+                }
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/test_snapshot_spec.json" <<EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "dual-compression-component",
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-pending/repo",
+                        "rh-registry-repo": "quay.io/redhat-pending/repo"
+                      }
+                    ],
+                    "containerImage": "quay.io/redhat-pending/repo@sha256:dualdigest"
+                  }
+                ]
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" <<EOF
+              {}
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: filter-already-released-advisory-images
+      params:
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/test_snapshot_spec.json"
+        - name: releasePlanAdmissionPath
+          value: "$(context.pipelineRun.uid)/test_release_plan_admission.json"
+        - name: resultsDirPath
+          value: "$(context.pipelineRun.uid)/results"
+        - name: synchronously
+          value: "false"
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)/$(context.pipelineRun.uid)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: dataPath
+          value: "$(context.pipelineRun.uid)/data.json"
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: result
+          value: $(tasks.run-task.results.result)
+        - name: skip_release
+          value: $(tasks.run-task.results.skip_release)
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: environment
+          value: $(tasks.run-task.results.environment)
+      runAfter:
+        - run-task
+      taskSpec:
+        params:
+          - name: environment
+            type: string
+          - name: result
+            type: string
+          - name: skip_release
+            type: string
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: verify
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -ex
+
+              # Count the number of InternalRequests
+              requestsCount=$(kubectl get InternalRequest -o json | jq -r '.items | length')
+
+              if [ "${requestsCount}" -ne 1 ]; then
+                echo "Unexpected number of InternalRequests. Expected: 1, Found: ${requestsCount}"
+                exit 1
+              fi
+
+              internalRequest=$(kubectl get InternalRequest -o json | jq -r '.items[0]')
+
+              # Check the transformedSnapshot parameter exists and decodes
+              transformedSnapshotB64=$(echo "$internalRequest" | jq -r '.spec.params.transformedSnapshot // empty')
+              if [ -z "${transformedSnapshotB64}" ]; then
+                echo "InternalRequest missing transformedSnapshot parameter"
+                exit 1
+              fi
+              transformedSnapshotJson=$(echo "${transformedSnapshotB64}" | base64 --decode | gzip -d)
+              if ! jq -e 'type=="array"' <<< "${transformedSnapshotJson}" >/dev/null; then
+                echo "transformedSnapshot should be a JSON array"
+                exit 1
+              fi
+
+              # The dedup filter should reduce 2 entries (1 arch x 2 compressions)
+              # to 1 entry (amd64 gzip only). Verify we have exactly 1 transformed
+              # component, not 2.
+              entryCount=$(jq 'length' <<< "${transformedSnapshotJson}")
+              if [ "$entryCount" -ne 1 ]; then
+                echo "Error: expected 1 transformed entry (after dedup), got $entryCount"
+                jq '.' <<< "${transformedSnapshotJson}"
+                exit 1
+              fi
+
+              # Verify the transformed component uses the gzip digest (not the zstd digest)
+              entry=$(jq -c '.[0]' <<< "${transformedSnapshotJson}")
+              if [[ "$(jq -r '.containerImage' <<< "$entry")" != *"@sha256:amd64gzip" ]]; then
+                echo "Error: transformed component should use gzip digest, got: $(jq -r '.containerImage' <<< "$entry")"
+                exit 1
+              fi
+
+              # Check that the result was properly set
+              if [ "$(params.result)" != "Success" ]; then
+                echo "Task failed: $(params.result)"
+                exit 1
+              fi
+
+              # Check that skip_release is set to false
+              if [ "$(params.skip_release)" != "false" ]; then
+                echo "skip_release should be false when the component is not yet released"
+                exit 1
+              fi
+
+              # Check that the environment task result was properly set
+              if [ "$(params.environment)" != "stage" ]; then
+                echo "The environment task result was not set properly"
+                exit 1
+              fi
+  finally:
+    - name: cleanup
+      taskSpec:
+        steps:
+          - name: delete-crs
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              kubectl delete internalrequests --all

--- a/tasks/managed/populate-release-notes/populate-release-notes.yaml
+++ b/tasks/managed/populate-release-notes/populate-release-notes.yaml
@@ -131,7 +131,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: validate-cve-issues-in-cves
-      image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+      image: quay.io/konflux-ci/release-service-utils@sha256:95f602cfb374c4798e4fbf3d298efe0218ac55308446d3f70f5df8add9675e83
       computeResources:
         limits:
           memory: 32Mi
@@ -238,7 +238,7 @@ spec:
         fi
         exit $RC
     - name: populate-release-notes-images
-      image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+      image: quay.io/konflux-ci/release-service-utils@sha256:95f602cfb374c4798e4fbf3d298efe0218ac55308446d3f70f5df8add9675e83
       computeResources:
         limits:
           memory: 64Mi
@@ -390,7 +390,7 @@ spec:
             done
         done
     - name: populate-release-notes-artifacts
-      image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+      image: quay.io/konflux-ci/release-service-utils@sha256:95f602cfb374c4798e4fbf3d298efe0218ac55308446d3f70f5df8add9675e83
       computeResources:
         limits:
           memory: 32Mi
@@ -647,7 +647,7 @@ spec:
         done
         cat "${DATA_FILE}"
     - name: populate-release-notes-github
-      image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+      image: quay.io/konflux-ci/release-service-utils@sha256:95f602cfb374c4798e4fbf3d298efe0218ac55308446d3f70f5df8add9675e83
       computeResources:
         limits:
           memory: 32Mi
@@ -761,7 +761,7 @@ spec:
                 /tmp/data.tmp && mv /tmp/data.tmp "${DATA_FILE}"
         done
     - name: populate-release-notes-type-and-references
-      image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+      image: quay.io/konflux-ci/release-service-utils@sha256:95f602cfb374c4798e4fbf3d298efe0218ac55308446d3f70f5df8add9675e83
       computeResources:
         limits:
           memory: 32Mi

--- a/tasks/managed/populate-release-notes/tests/mocks.sh
+++ b/tasks/managed/populate-release-notes/tests/mocks.sh
@@ -4,8 +4,14 @@ set -eux
 # mocks to be injected into task step scripts
 
 function get-image-architectures() {
-    echo '{"platform":{"architecture": "amd64", "os": "linux"}, "digest": "sha256:abcdefg"}'
-    echo '{"platform":{"architecture": "s390x", "os": "linux"}, "digest": "sha256:deadbeef"}'
+    if [[ "$1" == *"dual"* ]]; then
+        # Dual-compression index: get-image-architectures dedups to the gzip entry per arch
+        echo '{"platform":{"architecture": "amd64", "os": "linux"}, "digest": "sha256:amd64gzip"}'
+        echo '{"platform":{"architecture": "s390x", "os": "linux"}, "digest": "sha256:s390gzip"}'
+    else
+        echo '{"platform":{"architecture": "amd64", "os": "linux"}, "digest": "sha256:abcdefg"}'
+        echo '{"platform":{"architecture": "s390x", "os": "linux"}, "digest": "sha256:deadbeef"}'
+    fi
 }
 
 function curl-with-retry() {

--- a/tasks/managed/populate-release-notes/tests/test-populate-release-notes-dual-compression.yaml
+++ b/tasks/managed/populate-release-notes/tests/test-populate-release-notes-dual-compression.yaml
@@ -1,0 +1,199 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-populate-release-notes-dual-compression
+spec:
+  description: |
+    Run the populate-release-notes task with a dual-compression image index
+    that contains both gzip and zstd:chunked manifests per architecture.
+    get-image-architectures deduplicates to the gzip entry per architecture,
+    so the task should create only 2 release note image entries (not 4).
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
+              {
+                "releaseNotes": {
+                  "product_id": [
+                    123
+                  ],
+                  "product_name": "Red Hat Openstack Product",
+                  "product_version": "123",
+                  "cpe": "cpe:/a:example:openstack:el8",
+                  "type": "RHBA",
+                  "synopsis": "test synopsis",
+                  "topic": "test topic",
+                  "description": "test description",
+                  "solution": "test solution"
+                }
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp",
+                    "containerImage": "registry.io/dual-image@sha256:123456",
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-prod/product----repo",
+                        "rh-registry-repo": "registry.redhat.io/product/repo",
+                        "tags": [
+                          "foo",
+                          "bar"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: populate-release-notes
+      params:
+        - name: dataPath
+          value: "$(context.pipelineRun.uid)/data.json"
+        - name: snapshotPath
+          value: "$(context.pipelineRun.uid)/snapshot.json"
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              # The dedup filter should reduce 4 entries (2 arches x 2 compressions)
+              # to 2 entries (1 per arch, gzip only). Verify we have exactly 2
+              # image entries, not 4.
+              image_count=$(jq '.releaseNotes.content.images | length' \
+                "$(params.dataDir)/$(context.pipelineRun.uid)/data.json")
+              if [ "${image_count}" != "2" ]; then
+                echo "Error: expected 2 image entries (after dedup), got ${image_count}"
+                jq '.releaseNotes.content.images' \
+                  "$(params.dataDir)/$(context.pipelineRun.uid)/data.json"
+                exit 1
+              fi
+
+              # Verify amd64 entry uses the gzip digest (not the zstd digest)
+              imagearch1=$(jq '.releaseNotes.content.images[0]' \
+                "$(params.dataDir)/$(context.pipelineRun.uid)/data.json")
+              test "$(jq -r '.architecture' <<< "${imagearch1}")" == "amd64"
+              test "$(jq -r '.containerImage' <<< "${imagearch1}")" \
+                == "registry.redhat.io/product/repo@sha256:amd64gzip"
+
+              # Verify s390x entry uses the gzip digest (not the zstd digest)
+              imagearch2=$(jq '.releaseNotes.content.images[1]' \
+                "$(params.dataDir)/$(context.pipelineRun.uid)/data.json")
+              test "$(jq -r '.architecture' <<< "${imagearch2}")" == "s390x"
+              test "$(jq -r '.containerImage' <<< "${imagearch2}")" == "registry.redhat.io/product/repo@sha256:s390gzip"
+      runAfter:
+        - run-task

--- a/tasks/managed/push-snapshot/push-snapshot.yaml
+++ b/tasks/managed/push-snapshot/push-snapshot.yaml
@@ -129,7 +129,7 @@ spec:
         - name: caCertPath
           value: $(params.caCertPath)
     - name: push-snapshot
-      image: quay.io/konflux-ci/release-service-utils@sha256:3cb03b14ac9d90ff27070036ce2b50712e65aa285daeb28852254a745bb25dfc
+      image: quay.io/konflux-ci/release-service-utils@sha256:95f602cfb374c4798e4fbf3d298efe0218ac55308446d3f70f5df8add9675e83
       computeResources:
         limits:
           memory: 1Gi

--- a/tasks/managed/push-snapshot/tests/mocks.sh
+++ b/tasks/managed/push-snapshot/tests/mocks.sh
@@ -75,8 +75,14 @@ function skopeo() {
 }
 
 function get-image-architectures() {
-  echo '{"platform":{"architecture": "ppc64le", "os": "linux"}, "digest": "deadbeef"}'
-  echo '{"platform":{"architecture": "amd64", "os": "linux"}, "digest": "abcdefg"}'
+  local image="$1"
+  if [[ "$image" == *"dual"* ]]; then
+    # Dual-compression index: get-image-architectures dedups to the gzip entry per arch
+    echo '{"platform":{"architecture": "amd64", "os": "linux"}, "digest": "sha256:dualgzip"}'
+  else
+    echo '{"platform":{"architecture": "ppc64le", "os": "linux"}, "digest": "deadbeef"}'
+    echo '{"platform":{"architecture": "amd64", "os": "linux"}, "digest": "abcdefg"}'
+  fi
 }
 
 function select-oci-auth() {

--- a/tasks/managed/push-snapshot/tests/test-push-snapshot-dual-compression.yaml
+++ b/tasks/managed/push-snapshot/tests/test-push-snapshot-dual-compression.yaml
@@ -1,0 +1,180 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-push-snapshot-dual-compression
+spec:
+  description: |
+    Run the push-snapshot task with a dual-compression image index.
+    The image index contains both gzip and zstd:chunked manifests for amd64.
+    get-image-architectures deduplicates to the gzip entry, so the task should
+    store only one arch in the snapshot results JSON.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)/results"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot.json" << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp-dual",
+                    "containerImage": "registry.io/dual-image:tag",
+                    "repositories": [
+                      {
+                        "url": "prod-registry.io/prod-location",
+                        "tags": [
+                          "tag1"
+                        ]
+                      }
+                    ],
+                    "pushSourceContainer": false
+                  }
+                ]
+              }
+              EOF
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/data.json" << EOF
+              {
+                "mapping": {
+                  "defaults": {
+                    "pushSourceContainer": false
+                  }
+                }
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: push-snapshot
+      params:
+        - name: snapshotPath
+          value: $(context.pipelineRun.uid)/snapshot.json
+        - name: dataPath
+          value: $(context.pipelineRun.uid)/data.json
+        - name: retries
+          value: 0
+        - name: resultsDirPath
+          value: $(context.pipelineRun.uid)/results
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              RESULTS_FILE="$(params.dataDir)/$(context.pipelineRun.uid)/results/push-snapshot-results.json"
+
+              # The dedup filter should reduce 2 entries (1 arch x 2 compressions)
+              # to 1 entry (amd64 gzip only).
+              test "$(jq -r '.images[0].name' "${RESULTS_FILE}")" == "comp-dual"
+              test "$(jq -r '.images[0].arches | length' "${RESULTS_FILE}")" == "1"
+              test "$(jq -r '.images[0].arches[0]' "${RESULTS_FILE}")" == "amd64"
+              test "$(jq -r '.images[0].oses | length' "${RESULTS_FILE}")" == "1"
+              test "$(jq -r '.images[0].oses[0]' "${RESULTS_FILE}")" == "linux"
+              test "$(jq -r '.images[0].urls | length' "${RESULTS_FILE}")" == "1"
+      runAfter:
+        - run-task


### PR DESCRIPTION
## Describe your changes
get-image-architectures now deduplicates manifests per (architecture, os), keeping the non-zstd entry for dual-compression indexes (konflux-ci/release-service-utils#900). This PR bumps the release-service-utils image in the 5 tasks that loop over architectures: create-pyxis-image, extract-oot-kmods, populate-release-notes, filter-already-released-advisory-images and push-snapshot, and adds dual-compression regression tests for each.

The remaining consumers (apply-mapping, filter-published-fbc-images, get-ocp-version) only read the first entry and are unaffected, their image digests roll forward.

Ref: https://github.com/konflux-ci/architecture/pull/357

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [x] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
