### PR TITLE
fix: use kubectl apply for tenant resources retry

### DIFF
--- a/integration-tests/lib/test-functions.sh
+++ b/integration-tests/lib/test-functions.sh
@@ -366,13 +366,13 @@ create_kubernetes_resources() {
     local max_retries=5
     local attempt
     for attempt in $(seq 1 "${max_retries}"); do
-        if kubectl create -f "$tmpDir/tenant-resources.yaml"; then
+        if kubectl apply -f "$tmpDir/tenant-resources.yaml"; then
             break
         fi
         if [ "${attempt}" -eq "${max_retries}" ]; then
-            log_error "kubectl create tenant resources failed after ${max_retries} attempts"
+            log_error "kubectl apply tenant resources failed after ${max_retries} attempts"
         fi
-        echo "Retrying kubectl create tenant resources (attempt ${attempt}/${max_retries})..."
+        echo "Retrying kubectl apply tenant resources (attempt ${attempt}/${max_retries})..."
         sleep "$((1 + RANDOM % 3))"
     done
 


### PR DESCRIPTION
## Describe your changes

We previously fixed transient ResourceQuota conflict errors in PR #2375 (f8bebaaa) by wrapping the application of tenant and managed resources in a retry loop. However, tenant resources were applied with kubectl create, which is not idempotent: if at least one resource was successfully created on the first attempt, every retry would fail with AlreadyExists for that resource, even after the transient conflict cleared, exhausting all retries.

Switch to kubectl apply, matching the managed resources retry loop, so retries are idempotent and only need to succeed on the resources that weren't created yet.

Here's the test run where it failed: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rhtap-release-2-tenant/applications/release-service-catalog-staging/pipelineruns/konflux-e2e-release-catalog-staging-58g8l?integrationTestName=konflux-e2e-release-catalog-staging

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
