### PR TITLE
fix(KFLUXSPRT-8470): add pulpTaskTimeout param to disk images push

### DIFF
--- a/pipelines/internal/push-disk-images/README.md
+++ b/pipelines/internal/push-disk-images/README.md
@@ -4,14 +4,15 @@ Tekton Pipeline to push disk images with Pulp
 
 ## Parameters
 
-| Name            | Description                                                                           | Optional | Default value                                             |
-|-----------------|---------------------------------------------------------------------------------------|----------|-----------------------------------------------------------|
-| snapshot_json   | String containing a JSON representation of the snapshot spec                          | No       | -                                                         |
-| exodusGwSecret  | Env specific secret containing the Exodus Gateway configs                             | No       | -                                                         |
-| exodusGwEnv     | Environment to use in the Exodus Gateway. Options are [live, pre]                     | No       | -                                                         |
-| pulpSecret      | Env specific secret containing the rhsm-pulp credentials                              | No       | -                                                         |
-| udcacheSecret   | Env specific secret containing the udcache credentials                                | No       | -                                                         |
-| cgwHostname     | The hostname of the content-gateway to publish the metadata to                        | Yes      | https://developers.redhat.com/content-gateway/rest/admin  |
-| cgwSecret       | Env specific secret containing the content gateway credentials                        | No       | -                                                         |
-| taskGitUrl      | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
-| taskGitRevision | The revision in the taskGitUrl repo to be used                                        | No       | -                                                         |
+| Name            | Description                                                                                                                | Optional | Default value                                             |
+|-----------------|----------------------------------------------------------------------------------------------------------------------------|----------|-----------------------------------------------------------|
+| snapshot_json   | String containing a JSON representation of the snapshot spec                                                               | No       | -                                                         |
+| exodusGwSecret  | Env specific secret containing the Exodus Gateway configs                                                                  | No       | -                                                         |
+| exodusGwEnv     | Environment to use in the Exodus Gateway. Options are [live, pre]                                                          | No       | -                                                         |
+| pulpSecret      | Env specific secret containing the rhsm-pulp credentials                                                                   | No       | -                                                         |
+| udcacheSecret   | Env specific secret containing the udcache credentials                                                                     | No       | -                                                         |
+| cgwHostname     | The hostname of the content-gateway to publish the metadata to                                                             | Yes      | https://developers.redhat.com/content-gateway/rest/admin  |
+| cgwSecret       | Env specific secret containing the content gateway credentials                                                             | No       | -                                                         |
+| pulpTaskTimeout | Maximum time in seconds to wait for a Pulp task to reach a terminal state during pre-push cleanup (default 7200 = 2 hours) | Yes      | 7200                                                      |
+| taskGitUrl      | The url to the git repo where the release-service-catalog tasks to be used are stored                                      | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
+| taskGitRevision | The revision in the taskGitUrl repo to be used                                                                             | No       | -                                                         |

--- a/pipelines/internal/push-disk-images/push-disk-images.yaml
+++ b/pipelines/internal/push-disk-images/push-disk-images.yaml
@@ -32,6 +32,12 @@ spec:
     - name: cgwSecret
       type: string
       description: Env specific secret containing the content gateway credentials
+    - name: pulpTaskTimeout
+      type: string
+      description: >-
+        Maximum time in seconds to wait for a Pulp task to reach a terminal
+        state during pre-push cleanup (default 7200 = 2 hours)
+      default: "7200"
     - name: taskGitUrl
       type: string
       description: The url to the git repo where the release-service-catalog tasks to be used are stored
@@ -66,6 +72,8 @@ spec:
           value: $(params.cgwHostname)
         - name: cgwSecret
           value: $(params.cgwSecret)
+        - name: pulpTaskTimeout
+          value: $(params.pulpTaskTimeout)
   results:
     - name: result
       value: $(tasks.pulp-push-disk-images.results.result)

--- a/pipelines/managed/push-disk-images-to-cdn/push-disk-images-to-cdn.yaml
+++ b/pipelines/managed/push-disk-images-to-cdn/push-disk-images-to-cdn.yaml
@@ -289,7 +289,7 @@ spec:
         - apply-mapping
     - name: push-disk-images
       retries: 3
-      timeout: "5h00m0s"
+      timeout: "24h00m0s"
       when:
         - input: "$(tasks.apply-mapping.results.mapped)"
           operator: in

--- a/tasks/internal/pulp-push-disk-images/README.md
+++ b/tasks/internal/pulp-push-disk-images/README.md
@@ -4,16 +4,17 @@ Tekton task to push disk images with Pulp
 
 ## Parameters
 
-| Name                   | Description                                                           | Optional | Default value |
-|------------------------|-----------------------------------------------------------------------|----------|---------------|
-| snapshot_json          | String containing a JSON representation of the snapshot spec          | No       | -             |
-| concurrentLimit        | The maximum number of images to be pulled at once                     | Yes      | 3             |
-| exodusGwSecret         | Env specific secret containing the Exodus Gateway configs             | No       | -             |
-| exodusGwEnv            | Environment to use in the Exodus Gateway. Options are [live, pre]     | No       | -             |
-| pulpSecret             | Env specific secret containing the rhsm-pulp credentials              | No       | -             |
-| udcacheSecret          | Env specific secret containing the udcache credentials                | No       | -             |
-| cgwHostname            | Env specific hostname for content gateway                             | No       | -             |
-| cgwSecret              | Env specific secret containing the content gateway credentials        | No       | -             |
-| caTrustConfigMapName   | The name of the ConfigMap to read CA bundle data from                 | Yes      | trusted-ca    |
-| caTrustConfigMapKey    | The name of the key in the ConfigMap that contains the CA bundle data | Yes      | ca-bundle.crt |
-| certExpirationWarnDays | Number of days before expiration to warn about certificate expiration | Yes      | 7             |
+| Name                   | Description                                                                                                                | Optional | Default value |
+|------------------------|----------------------------------------------------------------------------------------------------------------------------|----------|---------------|
+| snapshot_json          | String containing a JSON representation of the snapshot spec                                                               | No       | -             |
+| concurrentLimit        | The maximum number of images to be pulled at once                                                                          | Yes      | 3             |
+| exodusGwSecret         | Env specific secret containing the Exodus Gateway configs                                                                  | No       | -             |
+| exodusGwEnv            | Environment to use in the Exodus Gateway. Options are [live, pre]                                                          | No       | -             |
+| pulpSecret             | Env specific secret containing the rhsm-pulp credentials                                                                   | No       | -             |
+| udcacheSecret          | Env specific secret containing the udcache credentials                                                                     | No       | -             |
+| cgwHostname            | Env specific hostname for content gateway                                                                                  | No       | -             |
+| cgwSecret              | Env specific secret containing the content gateway credentials                                                             | No       | -             |
+| caTrustConfigMapName   | The name of the ConfigMap to read CA bundle data from                                                                      | Yes      | trusted-ca    |
+| caTrustConfigMapKey    | The name of the key in the ConfigMap that contains the CA bundle data                                                      | Yes      | ca-bundle.crt |
+| certExpirationWarnDays | Number of days before expiration to warn about certificate expiration                                                      | Yes      | 7             |
+| pulpTaskTimeout        | Maximum time in seconds to wait for a Pulp task to reach a terminal state during pre-push cleanup (default 7200 = 2 hours) | Yes      | 7200          |

--- a/tasks/internal/pulp-push-disk-images/pulp-push-disk-images.yaml
+++ b/tasks/internal/pulp-push-disk-images/pulp-push-disk-images.yaml
@@ -47,6 +47,12 @@ spec:
       type: string
       description: Number of days before expiration to warn about certificate expiration
       default: "7"
+    - name: pulpTaskTimeout
+      type: string
+      description: >-
+        Maximum time in seconds to wait for a Pulp task to reach a terminal
+        state during pre-push cleanup (default 7200 = 2 hours)
+      default: "7200"
   results:
     - name: result
       description: Success if the task succeeds, the error otherwise
@@ -86,7 +92,7 @@ spec:
 
   steps:
     - name: pull-and-push-images
-      image: quay.io/konflux-ci/release-service-utils@sha256:42d0820b4a7a5998a0d8f9549928120f0d527a7e78336ed0e33b6543057d74af
+      image: quay.io/konflux-ci/release-service-utils@sha256:a91acd22c0d064dd34d183457a844aae82fb48b647d46c27f2f0dbe61b461409
       computeResources:
         limits:
           memory: 512Mi
@@ -323,6 +329,7 @@ spec:
 
         pulp_push_wrapper --debug --source "${DISK_IMAGE_DIR}" --pulp-url "$PULP_URL" \
           --pulp-cert $PULP_CERT_FILE --pulp-key $PULP_KEY_FILE --udcache-url "$UDC_URL" \
+          --pulp-task-timeout-seconds "$(params.pulpTaskTimeout)" \
           2> >(tee -a "$STDERR_FILE" >&2)
 
         relative_paths=$(echo "$STAGED_JSON" | jq -erc .payload.files[].relative_path)

--- a/tasks/internal/pulp-push-disk-images/pulp-push-disk-images.yaml
+++ b/tasks/internal/pulp-push-disk-images/pulp-push-disk-images.yaml
@@ -47,6 +47,12 @@ spec:
       type: string
       description: Number of days before expiration to warn about certificate expiration
       default: "7"
+    - name: pulpTaskTimeout
+      type: string
+      description: >-
+        Maximum time in seconds to wait for a Pulp task to reach a terminal
+        state during pre-push cleanup (default 7200 = 2 hours)
+      default: "7200"
   results:
     - name: result
       description: Success if the task succeeds, the error otherwise
@@ -86,7 +92,7 @@ spec:
 
   steps:
     - name: pull-and-push-images
-      image: quay.io/konflux-ci/release-service-utils@sha256:42d0820b4a7a5998a0d8f9549928120f0d527a7e78336ed0e33b6543057d74af
+      image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-d12c556fe2e38025a43821fcda3b17bd581e119c
       computeResources:
         limits:
           memory: 512Mi
@@ -323,6 +329,7 @@ spec:
 
         pulp_push_wrapper --debug --source "${DISK_IMAGE_DIR}" --pulp-url "$PULP_URL" \
           --pulp-cert $PULP_CERT_FILE --pulp-key $PULP_KEY_FILE --udcache-url "$UDC_URL" \
+          --pulp-task-timeout-seconds "$(params.pulpTaskTimeout)" \
           2> >(tee -a "$STDERR_FILE" >&2)
 
         relative_paths=$(echo "$STAGED_JSON" | jq -erc .payload.files[].relative_path)

--- a/tasks/internal/pulp-push-disk-images/tests/mocks.sh
+++ b/tasks/internal/pulp-push-disk-images/tests/mocks.sh
@@ -45,6 +45,11 @@ function gzip() {
 function pulp_push_wrapper() {
     echo Mock pulp_push_wrapper called with: $*
 
+    if [[ ! "$*" =~ --pulp-task-timeout-seconds[[:space:]]+[1-9][0-9]* ]]; then
+        echo "Error: pulp_push_wrapper called without a valid positive --pulp-task-timeout-seconds value"
+        exit 1
+    fi
+
     if [[ "$*" != *"--pulp-url https://pulp.com"* ]]; then
         printf "Mocked failure of pulp_push_wrapper" > /nonexistent/location
     fi


### PR DESCRIPTION
Threads a new pulpTaskTimeout param (default 300s) through to pulp_push_wrapper's --pulp-task-timeout-seconds flag, matching the fix landing in release-service-utils for the same incident.

NOTE: the pinned release-service-utils image digest on line 89 does not yet contain --pulp-task-timeout-seconds support. This branch is not mergeable until that digest is bumped in a follow-up commit once the utils PR lands.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [x] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
