### PR TITLE
fix(KONFLUX-13739): check fbc opt-in correct path

### DIFF
--- a/tasks/internal/check-fbc-opt-in/check-fbc-opt-in.yaml
+++ b/tasks/internal/check-fbc-opt-in/check-fbc-opt-in.yaml
@@ -75,7 +75,8 @@ spec:
         readOnly: true
   steps:
     - name: check-opt-in
-      image: quay.io/konflux-ci/release-service-utils@sha256:2ae61d5886887b230860934bfc7719453e44bc8882fab5ad84a483a720c5763d
+      image: >-
+        quay.io/konflux-ci/release-service-utils@sha256:891c755bcf6ad93dfe62c83b4653b1a2ec90f02826b0e06396a8f58360ec15d3
       computeResources:
         limits:
           memory: 512Mi


### PR DESCRIPTION
this commit updates the image to use the new version of check-fbc-opt-in that uses repo instead of image in pyxis url

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
