### PR TITLE
feat(CALUNGA-380): add calunga-push-to-pulp-lightwell release pipeline

### DIFF
--- a/pipelines/managed/calunga-push-to-pulp-lightwell/README.md
+++ b/pipelines/managed/calunga-push-to-pulp-lightwell/README.md
@@ -1,0 +1,25 @@
+# calunga-push-to-pulp-lightwell pipeline
+
+Release Components in a Snapshot to a pulp-backed python index. Each image in a Component is expected to contain a python wheel and sdist under the /releases directory. This is the Lightwell variant without advisory creation or SBOM uploads to Atlas.
+
+## Parameters
+
+| Name                            | Description                                                                                                                        | Optional | Default value                                             |
+|---------------------------------|------------------------------------------------------------------------------------------------------------------------------------|----------|-----------------------------------------------------------|
+| release                         | The namespaced name (namespace/name) of the Release custom resource initiating this pipeline execution                             | No       | -                                                         |
+| releasePlan                     | The namespaced name (namespace/name) of the releasePlan                                                                            | No       | -                                                         |
+| releasePlanAdmission            | The namespaced name (namespace/name) of the releasePlanAdmission                                                                   | No       | -                                                         |
+| releaseServiceConfig            | The namespaced name (namespace/name) of the releaseServiceConfig                                                                   | No       | -                                                         |
+| snapshot                        | The namespaced name (namespace/name) of the snapshot                                                                               | No       | -                                                         |
+| enterpriseContractPolicy        | JSON representation of the EnterpriseContractPolicy                                                                                | No       | -                                                         |
+| enterpriseContractExtraRuleData | Extra rule data to be merged into the policy specified in params.enterpriseContractPolicy. Use syntax "key1=value1,key2=value2..." | Yes      | pipeline_intention=release                                |
+| enterpriseContractTimeout       | Timeout setting for `ec validate`                                                                                                  | Yes      | 40m0s                                                     |
+| taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                                              | Yes      | https://github.com/konflux-ci/release-service-catalog.git |
+| taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                                                     | Yes      | production                                                |
+| pulpBaseUrl                     | The base URL of the Pulp server                                                                                                    | Yes      | https://packages.redhat.com                               |
+| pulpDomain                      | The domain to use for Pulp operations                                                                                              | Yes      | public-trusted-libraries                                  |
+| pulpApiRoot                     | The API root path of the Pulp server                                                                                               | Yes      | /api/                                                     |
+| serviceAccountSecretName        | The name of the secret containing the Pulp service account credentials                                                             | Yes      | rhtl-pulp-credentials-secret                              |
+| pulpRepository                  | The Pulp repository to upload packages to                                                                                          | Yes      | main                                                      |
+| signingSecretName               | The name of the AWS KMS signing secret                                                                                             | Yes      | konflux-cosign-signing-production                         |
+| config                          | Name of the ConfigMap with config options, e.g. ociStorage                                                                         | Yes      | release-pipeline-config                                   |

--- a/pipelines/managed/calunga-push-to-pulp-lightwell/calunga-push-to-pulp-lightwell.yaml
+++ b/pipelines/managed/calunga-push-to-pulp-lightwell/calunga-push-to-pulp-lightwell.yaml
@@ -1,0 +1,293 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: calunga-push-to-pulp-lightwell
+spec:
+  description: >-
+    Release Components in a Snapshot to a pulp-backed python index. Each image in a Component is
+    expected to contain a python wheel and sdist under the /releases directory. This is the Lightwell
+    variant without advisory creation or SBOM uploads to Atlas.
+  params:
+    - name: release
+      type: string
+      description:
+        The namespaced name (namespace/name) of the Release custom resource initiating this pipeline execution
+    - name: releasePlan
+      type: string
+      description: The namespaced name (namespace/name) of the releasePlan
+    - name: releasePlanAdmission
+      type: string
+      description: The namespaced name (namespace/name) of the releasePlanAdmission
+    - name: releaseServiceConfig
+      type: string
+      description: The namespaced name (namespace/name) of the releaseServiceConfig
+    - name: snapshot
+      type: string
+      description: The namespaced name (namespace/name) of the snapshot
+    - name: enterpriseContractPolicy
+      type: string
+      description: JSON representation of the EnterpriseContractPolicy
+    - name: enterpriseContractExtraRuleData
+      type: string
+      description: |
+        Extra rule data to be merged into the policy specified in params.enterpriseContractPolicy. Use syntax
+        "key1=value1,key2=value2..."
+      default: "pipeline_intention=release"
+    - name: enterpriseContractTimeout
+      type: string
+      description: Timeout setting for `ec validate`
+      default: 40m0s
+    - name: taskGitUrl
+      type: string
+      description: The url to the git repo where the release-service-catalog tasks to be used are stored
+      default: https://github.com/konflux-ci/release-service-catalog.git
+    - name: taskGitRevision
+      type: string
+      description: The revision in the taskGitUrl repo to be used
+      default: production
+    - name: pulpBaseUrl
+      type: string
+      description: The base URL of the Pulp server
+      default: https://packages.redhat.com
+    - name: pulpDomain
+      type: string
+      description: The domain to use for Pulp operations
+      default: public-trusted-libraries
+    - name: pulpApiRoot
+      type: string
+      description: The API root path of the Pulp server
+      default: "/api/"
+    - name: serviceAccountSecretName
+      type: string
+      description: The name of the secret containing the Pulp service account credentials
+      default: rhtl-pulp-credentials-secret
+    - name: pulpRepository
+      type: string
+      description: The Pulp repository to upload packages to
+      default: main
+    - name: signingSecretName
+      type: string
+      description: The name of the AWS KMS signing secret
+      default: konflux-cosign-signing-production
+    - name: config
+      description: Name of the ConfigMap with config options, e.g. ociStorage
+      type: string
+      default: release-pipeline-config
+  tasks:
+
+    - name: config
+      taskRef:
+        params:
+          - name: name
+            value: get-config
+          - name: bundle
+            value: quay.io/redhat-user-workloads/calunga-tenant/task-get-config@sha256:abe408d7365a23a548268b994dc7d758660fc595ba6af0f455f000a4f3f535d7
+          - name: kind
+            value: task
+        resolver: bundles
+      params:
+        - name: configMapName
+          value: $(params.config)
+
+    - name: collect-data
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/collect-data/collect-data.yaml
+      params:
+        - name: release
+          value: $(params.release)
+        - name: releasePlan
+          value: $(params.releasePlan)
+        - name: releasePlanAdmission
+          value: $(params.releasePlanAdmission)
+        - name: releaseServiceConfig
+          value: $(params.releaseServiceConfig)
+        - name: snapshot
+          value: $(params.snapshot)
+        - name: subdirectory
+          value: $(context.pipelineRun.uid)
+        - name: taskGitUrl
+          value: $(params.taskGitUrl)
+        - name: taskGitRevision
+          value: $(params.taskGitRevision)
+        - name: ociStorage
+          value: $(tasks.config.results.ociStorage)
+
+    - name: reduce-snapshot
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/reduce-snapshot/reduce-snapshot.yaml
+      params:
+        - name: SNAPSHOT
+          value: $(workspaces.data.path)/$(tasks.collect-data.results.snapshotSpec)
+        - name: SINGLE_COMPONENT
+          value: $(tasks.collect-data.results.singleComponentMode)
+        - name: SINGLE_COMPONENT_CUSTOM_RESOURCE
+          value: snapshot/$(tasks.collect-data.results.snapshotName)
+        - name: SINGLE_COMPONENT_CUSTOM_RESOURCE_NS
+          value: $(tasks.collect-data.results.snapshotNamespace)
+        - name: SNAPSHOT_PATH
+          value: $(workspaces.data.path)/$(tasks.collect-data.results.snapshotSpec)
+        - name: taskGitUrl
+          value: $(params.taskGitUrl)
+        - name: taskGitRevision
+          value: $(params.taskGitRevision)
+        - name: sourceDataArtifact
+          value: "$(tasks.collect-data.results.sourceDataArtifact)"
+        - name: ociStorage
+          value: $(tasks.config.results.ociStorage)
+      runAfter:
+        - collect-data
+
+    - name: verify-enterprise-contract
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: https://github.com/enterprise-contract/ec-cli
+          - name: revision
+            value: cdfd9188f9352d7269ae1fe8c273a9e67f60ab8a
+          - name: pathInRepo
+            value: "tasks/verify-conforma-konflux-ta/0.1/verify-conforma-konflux-ta.yaml"
+      params:
+        - name: SNAPSHOT_FILENAME
+          value: "$(tasks.collect-data.results.snapshotSpec)"
+        - name: SSL_CERT_DIR
+          value: /var/run/secrets/kubernetes.io/serviceaccount
+        - name: POLICY_CONFIGURATION
+          value: $(params.enterpriseContractPolicy)
+        - name: STRICT
+          value: "true"
+        - name: IGNORE_REKOR
+          value: "true"
+        - name: EXTRA_RULE_DATA
+          value: $(params.enterpriseContractExtraRuleData)
+        - name: TIMEOUT
+          value: $(params.enterpriseContractTimeout)
+        - name: SOURCE_DATA_ARTIFACT
+          value: "$(tasks.reduce-snapshot.results.sourceDataArtifact)"
+      runAfter:
+        - reduce-snapshot
+
+    - name: extract-py-artifacts
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/extract-py-artifacts/extract-py-artifacts.yaml
+      params:
+        - name: SNAPSHOT_PATH
+          value: $(tasks.collect-data.results.snapshotSpec)
+        - name: sourceDataArtifact
+          value: "$(tasks.reduce-snapshot.results.sourceDataArtifact)"
+        - name: ociStorage
+          value: $(tasks.config.results.ociStorage)
+        - name: taskGitUrl
+          value: $(params.taskGitUrl)
+        - name: taskGitRevision
+          value: $(params.taskGitRevision)
+        - name: dataDir
+          value: /var/workdir/content
+        - name: dataPath
+          value: $(tasks.collect-data.results.data)
+      runAfter:
+        - verify-enterprise-contract
+
+    - name: rh-sign-python-wheels
+      timeout: "2h00m0s"
+      when:
+        - input: $(params.signingSecretName)
+          operator: notin
+          values: [""]
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/rh-sign-python-wheels/rh-sign-python-wheels.yaml
+      params:
+        - name: secretName
+          value: "$(params.signingSecretName)"
+        - name: sourceDataArtifact
+          value: "$(tasks.extract-py-artifacts.results.sourceDataArtifact)"
+        - name: ociStorage
+          value: $(tasks.config.results.ociStorage)
+        - name: taskGitUrl
+          value: $(params.taskGitUrl)
+        - name: taskGitRevision
+          value: $(params.taskGitRevision)
+      runAfter:
+        - extract-py-artifacts
+
+    - name: push-py-pulp
+      when:
+        - input: $(params.signingSecretName)
+          operator: notin
+          values: [""]
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/upload-py-pulp/upload-py-pulp.yaml
+      params:
+        - name: PULP_BASE_URL
+          value: $(params.pulpBaseUrl)
+        - name: PULP_API_ROOT
+          value: $(params.pulpApiRoot)
+        - name: PULP_DOMAIN
+          value: $(params.pulpDomain)
+        - name: SERVICE_ACCOUNT_SECRET_NAME
+          value: $(params.serviceAccountSecretName)
+        - name: PULP_REPOSITORY
+          value: $(params.pulpRepository)
+        - name: sourceDataArtifact
+          value: "$(tasks.rh-sign-python-wheels.results.sourceDataArtifact)"
+        - name: dataDir
+          value: /var/workdir/content
+        - name: taskGitUrl
+          value: $(params.taskGitUrl)
+        - name: taskGitRevision
+          value: $(params.taskGitRevision)
+        - name: ociStorage
+          value: $(tasks.config.results.ociStorage)
+      runAfter:
+        - rh-sign-python-wheels
+
+  finally:
+    - name: cleanup-internal-requests
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/cleanup-internal-requests/cleanup-internal-requests.yaml
+      params:
+        - name: pipelineRunUid
+          value: $(context.pipelineRun.uid)


### PR DESCRIPTION
Add a new Lightwell-specific release pipeline for publishing Python wheels to the Lightwell Pulp domain. This is a variant of the existing calunga-push-to-pulp pipeline with advisory and Atlas functionality removed.

Changes:
- Add calunga-push-to-pulp-lightwell pipeline and README

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [x] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
