### PR TITLE
fix(RELEASE-2749): bump release-service-utils image for cdn push

### DIFF
--- a/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
@@ -179,7 +179,7 @@ spec:
 
   steps:
     - name: push-artifacts-to-cdn
-      image: quay.io/konflux-ci/release-service-utils@sha256:0b35e861c83b9c1141e3a8d7a8924cc9c4ae0b09dc87938971eee66ee9b9aaaf
+      image: quay.io/konflux-ci/release-service-utils@sha256:f88c25bacfd8575198419a8465804980ba6531dfb2b4717a7ebc4415df43910d
       securityContext:
         runAsUser: 1001
       computeResources:

--- a/tasks/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
@@ -132,7 +132,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: run-script
-      image: quay.io/konflux-ci/release-service-utils@sha256:0b35e861c83b9c1141e3a8d7a8924cc9c4ae0b09dc87938971eee66ee9b9aaaf
+      image: quay.io/konflux-ci/release-service-utils@sha256:f88c25bacfd8575198419a8465804980ba6531dfb2b4717a7ebc4415df43910d
       computeResources:
         limits:
           memory: 512Mi


### PR DESCRIPTION
Bump the release-service-utils image digest in both the push-artifacts-to-cdn task and the internal push-artifacts-to-cdn-task to pick up konflux-ci/release-service-utils#927, which signs Windows staging binaries using the Local Machine certificate store so signing survives host reboots and password rotations.

Assisted-by: Cursor AI

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [x] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
