### PR TITLE
feat(RELEASE-2758): add multi-arch OCI image index support

### DIFF
--- a/tasks/managed/marketplacesvm-push-disk-images/marketplacesvm-push-disk-images.yaml
+++ b/tasks/managed/marketplacesvm-push-disk-images/marketplacesvm-push-disk-images.yaml
@@ -150,6 +150,7 @@ spec:
       script: |
         #!/usr/bin/env bash
         set -eux
+        set -o pipefail
 
         echo "DEBUG: Sanity validation of credentials"
         JSON_FILES=(/etc/secrets/*.json)
@@ -189,6 +190,14 @@ spec:
         RUNNING_JOBS="\j" # Bash parameter for number of jobs currently running
         NUM_COMPONENTS=$(jq '.components | length' <<< "$SNAPSHOT_JSON")
 
+        rh_arch_to_oci_platform() {
+            case "$1" in
+                x86_64)  echo "linux/amd64" ;;
+                aarch64) echo "linux/arm64" ;;
+                *)       echo "linux/$1" ;;
+            esac
+        }
+
         prepare_component() { # Expected argument is [component json]
             COMPONENT=$1
             PRODUCT_INFO=$(jq -c '.productInfo' <<< "${COMPONENT}")
@@ -224,28 +233,91 @@ spec:
             DESTINATION="${DISK_IMGS_DIR}/${IMG_NAME}"
             mkdir -p "${DESTINATION}"
             DOWNLOAD_DIR=$(mktemp -d -p /var/workdir)
-            cd "$DOWNLOAD_DIR"
             # oras has very limited support for selecting the right auth entry,
             # so create a custom auth file with just one entry
             AUTH_FILE=$(mktemp)
             select-oci-auth "${PULLSPEC}" > "$AUTH_FILE"
-            oras pull --registry-config "$AUTH_FILE" "$PULLSPEC"
+            trap 'rm -rf "${DOWNLOAD_DIR}"; rm -f "${AUTH_FILE}"' EXIT
+
+            # Detect whether the image is a multi-arch index. An index mediaType alone is not
+            # sufficient: it can legally wrap a single manifest, so only treat it as multi-arch
+            # when it actually contains more than one manifest entry.
+            MANIFEST_JSON=$(oras manifest fetch --registry-config "${AUTH_FILE}" "${PULLSPEC}")
+            MEDIA_TYPE=$(jq -r '.mediaType' <<< "${MANIFEST_JSON}")
+            IS_MULTIARCH=false
+            if [[ "$MEDIA_TYPE" == "application/vnd.docker.distribution.manifest.list.v2+json" ]] \
+                || [[ "$MEDIA_TYPE" == "application/vnd.oci.image.index.v1+json" ]]; then
+                MANIFEST_COUNT=$(jq '.manifests | length' <<< "${MANIFEST_JSON}")
+                if [[ "$MANIFEST_COUNT" -gt 1 ]]; then
+                    IS_MULTIARCH=true
+                    # oras selects a manifest from the index via platform.architecture. Some
+                    # multi-arch OCI artifact indexes are built without per-manifest platform
+                    # metadata (see RHELOPC-2342), which makes --platform selection impossible.
+                    # Fail loudly instead of guessing which manifest belongs to which arch.
+                    if jq -e '[.manifests[].platform.architecture] | any(. == null)' \
+                        <<< "${MANIFEST_JSON}" > /dev/null; then
+                        echo "ERROR: Multi-arch image index for ${PULLSPEC} has one or more" \
+                            "manifests without platform.architecture metadata; oras cannot" \
+                            "select the correct architecture." >&2
+                        exit 1
+                    fi
+                fi
+            fi
+
+            if [[ "$IS_MULTIARCH" == "true" ]]; then
+                # Pull once per architecture into a separate subdirectory. Fail if the same
+                # architecture appears more than once in staged.files, since that scenario is
+                # untested and its correct handling is undefined.
+                mapfile -t COMPONENT_ARCHS < <(jq -r \
+                    '[.staged.files[].filename
+                      | sub("\\.gz$"; "") | sub("\\.[^.]+$"; "")
+                      | split("-") | last
+                    ] | .[]' \
+                    <<< "$COMPONENT")
+                if [[ $(printf '%s\n' "${COMPONENT_ARCHS[@]}" | sort | uniq -d | wc -l) -gt 0 ]]; then
+                    echo "ERROR: staged.files has more than one file for the same architecture," \
+                        "which is not supported for multi-arch images." >&2
+                    exit 1
+                fi
+                for ARCH in "${COMPONENT_ARCHS[@]}"; do
+                    OCI_PLATFORM=$(rh_arch_to_oci_platform "$ARCH")
+                    ARCH_DIR="${DOWNLOAD_DIR}/${ARCH}"
+                    mkdir -p "$ARCH_DIR"
+                    cd "$ARCH_DIR"
+                    oras pull --registry-config "${AUTH_FILE}" --platform "${OCI_PLATFORM}" "${PULLSPEC}"
+                done
+            else
+                cd "$DOWNLOAD_DIR"
+                oras pull --registry-config "${AUTH_FILE}" "${PULLSPEC}"
+            fi
+
             NUM_MAPPED_FILES=$(jq '.staged.files | length' <<< "${COMPONENT}")
             for ((i = 0; i < NUM_MAPPED_FILES; i++)); do
                 FILE=$(jq -c --arg i "$i" '.staged.files[$i|tonumber]' <<< "$COMPONENT")
                 SOURCE=$(jq -er '.source' <<< "$FILE")
                 FILENAME=$(jq -er '.filename' <<< "$FILE")
 
+                # Resolve source path from the correct directory
+                if [[ "$IS_MULTIARCH" == "true" ]]; then
+                    FILE_ARCH=${FILENAME%.gz}
+                    FILE_ARCH=${FILE_ARCH%.*}
+                    FILE_ARCH=${FILE_ARCH##*-}
+                    SOURCE_PATH="${DOWNLOAD_DIR}/${FILE_ARCH}/${SOURCE}"
+                else
+                    SOURCE_PATH="${DOWNLOAD_DIR}/${SOURCE}"
+                fi
+
                 # Fail early if the source file pulled by ORAS does not exist
-                if [ ! -f "${SOURCE}" ]; then
-                    echo "ERROR: Source file '${SOURCE}' for component '${FILENAME}' was not found after oras pull." >&2
+                if [ ! -f "${SOURCE_PATH}" ]; then
+                    echo "ERROR: Source file '${SOURCE_PATH}' for component" \
+                        "'${FILENAME}' was not found after oras pull." >&2
                     exit 1
                 fi
 
                 # Decompress if the source file is gzipped
-                if [[ "${SOURCE}" == *.gz ]]; then
-                    gzip -d "${SOURCE}"
-                    SOURCE="${SOURCE%.gz}"
+                if [[ "${SOURCE_PATH}" == *.gz ]]; then
+                    gzip -d "${SOURCE_PATH}"
+                    SOURCE_PATH="${SOURCE_PATH%.gz}"
                     FILENAME="${FILENAME%.gz}"
                 fi
                 if [ -f "${DESTINATION}/${FILENAME}" ]; then
@@ -263,15 +335,13 @@ spec:
                     *)     echo "Skipping unsupported file: $FILENAME"; continue ;;
                 esac
 
-                mv "$SOURCE" "${DESTINATION}/${FILENAME}"
+                mv "$SOURCE_PATH" "${DESTINATION}/${FILENAME}"
                 RESOURCES_JSON=$(jq --arg filename "$FILENAME" --arg arch "$BUILD_ARCH" \
                     '.images[.images | length] = {"path": $filename, "architecture": $arch}' <<< "$RESOURCES_JSON")
                 RESOURCES_JSON=$(jq --arg image_type "$image_type" \
                     '.type = $image_type' <<< "$RESOURCES_JSON")
             done
             echo "$RESOURCES_JSON" | yq -P -I 4 > "$DESTINATION/resources.yaml"
-            rm -rf "$DOWNLOAD_DIR"
-            rm -f "$AUTH_FILE"
         }
 
         # Process each component in parallel with memory-aware job management

--- a/tasks/managed/marketplacesvm-push-disk-images/tests/mocks.sh
+++ b/tasks/managed/marketplacesvm-push-disk-images/tests/mocks.sh
@@ -13,21 +13,48 @@ function select-oci-auth() {
 }
 
 function oras() {
-    echo Mock oras called with: $*
-    echo $* > "$(params.dataDir)/mock_oras.txt"
-    pwd > "$(params.dataDir)/mock_oras_workdir.txt"
+    echo "Mock oras called with: $*" >&2
+    echo "$*" >> "$(params.dataDir)/mock_oras.txt"
 
-    if [[ "$*" != "pull --registry-config"* ]]; then
+    if [[ "$*" == "manifest fetch --registry-config"* ]]; then
+        # Return different index shapes based on markers in the pullspec, to exercise the
+        # multi-arch detection logic in the task
+        if [[ "$*" == *"multiarch-no-platform"* ]]; then
+            # Index with 2 manifests but no platform metadata (see RHELOPC-2342)
+            echo '{"mediaType": "application/vnd.oci.image.index.v1+json", "manifests": [
+                {"mediaType": "application/vnd.oci.image.manifest.v1+json", "digest": "sha256:aaa", "size": 1},
+                {"mediaType": "application/vnd.oci.image.manifest.v1+json", "digest": "sha256:bbb", "size": 1}
+            ]}'
+        elif [[ "$*" == *"multiarch-single-manifest"* ]]; then
+            # Index with only 1 manifest: not really multi-arch
+            echo '{"mediaType": "application/vnd.oci.image.index.v1+json", "manifests": [
+                {"mediaType": "application/vnd.oci.image.manifest.v1+json", "digest": "sha256:aaa", "size": 1,
+                 "platform": {"architecture": "amd64", "os": "linux"}}
+            ]}'
+        elif [[ "$*" == *"multiarch"* ]]; then
+            # Genuine multi-arch index with platform metadata on every manifest
+            echo '{"mediaType": "application/vnd.oci.image.index.v1+json", "manifests": [
+                {"mediaType": "application/vnd.oci.image.manifest.v1+json", "digest": "sha256:aaa", "size": 1,
+                 "platform": {"architecture": "amd64", "os": "linux"}},
+                {"mediaType": "application/vnd.oci.image.manifest.v1+json", "digest": "sha256:bbb", "size": 1,
+                 "platform": {"architecture": "arm64", "os": "linux"}}
+            ]}'
+        else
+            echo '{"mediaType": "application/vnd.oci.image.manifest.v1+json"}'
+        fi
+    elif [[ "$*" == "pull --registry-config"* ]]; then
+        pwd >> "$(params.dataDir)/mock_oras_workdir.txt"
+
+        # Simulate downloaded artifact: create a compressed disk image
+        # Determine the disk format from the pullspec
+        if [[ "$*" == *"azure"* ]]; then
+            echo "dummy disk image content" | gzip > disk.vhd.gz
+        else
+            echo "dummy disk image content" | gzip > disk.raw.gz
+        fi
+    else
         echo Error: Unexpected call to oras
         exit 1
-    fi
-
-    # Simulate downloaded artifact: create a compressed disk image
-    # Determine the disk format from the pullspec
-    if [[ "$*" == *"azure"* ]]; then
-        echo "dummy disk image content" | gzip > disk.vhd.gz
-    else
-        echo "dummy disk image content" | gzip > disk.raw.gz
     fi
 }
 

--- a/tasks/managed/marketplacesvm-push-disk-images/tests/test-marketplacesvm-push-azure-disk-images-pre-push.yaml
+++ b/tasks/managed/marketplacesvm-push-disk-images/tests/test-marketplacesvm-push-azure-disk-images-pre-push.yaml
@@ -232,12 +232,16 @@ spec:
                   cat "$(params.dataDir)/mock_select-oci-auth.txt"
                   exit 1
               fi
-              if [[ $(wc -l < "$(params.dataDir)/mock_oras.txt") != 1 ]]; then
-                  echo "Error: oras was expected to be called a 1 time. Actual calls:"
+              if [[ $(wc -l < "$(params.dataDir)/mock_oras.txt") != 2 ]]; then
+                  echo "Error: oras was expected to be called 2 times (manifest fetch + pull). Actual calls:"
                   cat "$(params.dataDir)/mock_oras.txt"
                   exit 1
-              elif [[ $(<"$(params.dataDir)/mock_oras.txt") != *"$expected_pullspec" ]]; then
-                  echo "Error: oras was expected to be called pullspec $expected_pullspec. Actual: "
+              elif ! grep -q "manifest fetch.*$expected_pullspec" "$(params.dataDir)/mock_oras.txt"; then
+                  echo "Error: oras manifest fetch was expected for $expected_pullspec. Actual:"
+                  cat "$(params.dataDir)/mock_oras.txt"
+                  exit 1
+              elif ! grep -q "pull.*$expected_pullspec" "$(params.dataDir)/mock_oras.txt"; then
+                  echo "Error: oras pull was expected for $expected_pullspec. Actual:"
                   cat "$(params.dataDir)/mock_oras.txt"
                   exit 1
               fi

--- a/tasks/managed/marketplacesvm-push-disk-images/tests/test-marketplacesvm-push-disk-images-fail-multiarch-duplicate-arch.yaml
+++ b/tasks/managed/marketplacesvm-push-disk-images/tests/test-marketplacesvm-push-disk-images-fail-multiarch-duplicate-arch.yaml
@@ -1,0 +1,197 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-marketplacesvm-push-disk-images-fail-multiarch-duplicate-arch
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the marketplacesvm-push-disk-images task with a multi-arch component whose
+    staged.files contains two files for the same architecture. That scenario is not
+    supported, so the task must fail loudly instead of silently deduplicating.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+          securityContext:
+            runAsUser: 1001
+        steps:
+          - name: setup
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/results"
+              RNOTES="Launch the product via 1-Click or the "
+              RNOTES+="marketplace listing.\n2. Access your "
+              RNOTES+="instance using ssh\n    * Open an SSH client\n"
+              cat > "$(params.dataDir)/snapshot_spec.json" << EOF
+              {
+                "application": "multiarch-bootc-1-3-raw-disk-image",
+                "artifacts": {},
+                "components": [
+                  {
+                    "containerImage": "quay.io/workload/tenant/test-product/multiarch-bootc-1-3-raw-disk-image@sha256:123456",
+                    "name": "multiarch-bootc-1-3-raw-disk-image",
+                    "source": {
+                      "git": {
+                        "context": ".",
+                        "dockerfileUrl": "bib-cuda-aws.yaml",
+                        "revision": "1abbfcdbc1c5e8b7aba07673297237ed192b50e2",
+                        "url": "https://gitlab.com/konflux/test-product/disk-images/amd-bootc"
+                      }
+                    },
+                    "contentType": "disk-image",
+                    "productInfo": {
+                      "filePrefix": "test-product-amd-1.3",
+                      "productCode": "TESTPRDOCUT",
+                      "productName": "Test Product",
+                      "productVersionName": "1.3"
+                    },
+                    "pushSourceContainer": false,
+                    "staged": {
+                      "destination": "test-product-1_DOT_3-multi-isos",
+                      "files": [
+                        {
+                          "filename": "test-product-amd-1.3-1732045201-x86_64.raw.gz",
+                          "source": "disk.raw.gz"
+                        },
+                        {
+                          "filename": "test-product-amd-1.3-1732045201-x86_64.qcow2.gz",
+                          "source": "disk.qcow2.gz"
+                        },
+                        {
+                          "filename": "test-product-amd-1.3-1732045201-aarch64.raw.gz",
+                          "source": "disk.raw.gz"
+                        }
+                      ],
+                      "version": "1.3"
+                    },
+                    "starmap": [
+                      {
+                        "cloud": "aws",
+                        "mappings": {
+                          "aws-emea": {
+                            "destinations": [
+                              {
+                                "architecture": "x86_64",
+                                "destination": "00000000-0000-0000-0000-000000000000",
+                                "overwrite": false,
+                                "restrict_version": true
+                              },
+                              {
+                                "architecture": "aarch64",
+                                "destination": "11111111-1111-1111-1111-111111111111",
+                                "overwrite": false,
+                                "restrict_version": true
+                              }
+                            ],
+                            "provider": null
+                          }
+                        },
+                        "meta": {
+                          "ena_support": true,
+                          "marketplace_entity_type": "AmiProduct",
+                          "recommended_instance_type": "p5.48xlarge",
+                          "release_notes": "${RNOTES}",
+                          "root_device": "/dev/sda1",
+                          "scanning_port": 22,
+                          "security_groups": [
+                            {
+                              "from_port": 22,
+                              "ip_protocol": "tcp",
+                              "ip_ranges": [
+                                "0.0.0.0/0"
+                              ],
+                              "to_port": 22
+                            }
+                          ],
+                          "sharing_accounts": [
+                            "111111111111"
+                          ],
+                          "sriov_net_support": "simple",
+                          "usage_instructions": "https://access.redhat.com/articles/xyz",
+                          "user_name": "cloud-user",
+                          "virtualization": "hvm",
+                          "volume": "gp3"
+                        },
+                        "name": "test-product-amd",
+                        "workflow": "stratosphere"
+                      }
+                    ]
+                  }
+                ]
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: marketplacesvm-push-disk-images
+      params:
+        - name: snapshotPath
+          value: "snapshot_spec.json"
+        - name: cloudMarketplacesSecret
+          value: marketplacesvm-test-secret
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup

--- a/tasks/managed/marketplacesvm-push-disk-images/tests/test-marketplacesvm-push-disk-images-fail-multiarch-no-platform.yaml
+++ b/tasks/managed/marketplacesvm-push-disk-images/tests/test-marketplacesvm-push-disk-images-fail-multiarch-no-platform.yaml
@@ -1,0 +1,194 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-marketplacesvm-push-disk-images-fail-multiarch-no-platform
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run the marketplacesvm-push-disk-images task with a multi-arch image index whose
+    manifests do not carry platform.architecture metadata (see RHELOPC-2342). The task
+    cannot safely select the correct architecture via oras --platform, so it must fail
+    loudly instead of guessing.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+          securityContext:
+            runAsUser: 1001
+        steps:
+          - name: setup
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/results"
+              RNOTES="Launch the product via 1-Click or the "
+              RNOTES+="marketplace listing.\n2. Access your "
+              RNOTES+="instance using ssh\n    * Open an SSH client\n"
+              cat > "$(params.dataDir)/snapshot_spec.json" << EOF
+              {
+                "application": "multiarch-no-platform-bootc-1-3-raw-disk-image",
+                "artifacts": {},
+                "components": [
+                  {
+                    "containerImage": "quay.io/workload/tenant/test-product/multiarch-no-platform-bootc-1-3-raw-disk-image@sha256:123456",
+                    "name": "multiarch-no-platform-bootc-1-3-raw-disk-image",
+                    "source": {
+                      "git": {
+                        "context": ".",
+                        "dockerfileUrl": "bib-cuda-aws.yaml",
+                        "revision": "1abbfcdbc1c5e8b7aba07673297237ed192b50e2",
+                        "url": "https://gitlab.com/konflux/test-product/disk-images/amd-bootc"
+                      }
+                    },
+                    "contentType": "disk-image",
+                    "productInfo": {
+                      "filePrefix": "test-product-amd-1.3",
+                      "productCode": "TESTPRDOCUT",
+                      "productName": "Test Product",
+                      "productVersionName": "1.3"
+                    },
+                    "pushSourceContainer": false,
+                    "staged": {
+                      "destination": "test-product-1_DOT_3-multi-isos",
+                      "files": [
+                        {
+                          "filename": "test-product-amd-1.3-1732045201-x86_64.raw.gz",
+                          "source": "disk.raw.gz"
+                        },
+                        {
+                          "filename": "test-product-amd-1.3-1732045201-aarch64.raw.gz",
+                          "source": "disk.raw.gz"
+                        }
+                      ],
+                      "version": "1.3"
+                    },
+                    "starmap": [
+                      {
+                        "cloud": "aws",
+                        "mappings": {
+                          "aws-emea": {
+                            "destinations": [
+                              {
+                                "architecture": "x86_64",
+                                "destination": "00000000-0000-0000-0000-000000000000",
+                                "overwrite": false,
+                                "restrict_version": true
+                              },
+                              {
+                                "architecture": "aarch64",
+                                "destination": "11111111-1111-1111-1111-111111111111",
+                                "overwrite": false,
+                                "restrict_version": true
+                              }
+                            ],
+                            "provider": null
+                          }
+                        },
+                        "meta": {
+                          "ena_support": true,
+                          "marketplace_entity_type": "AmiProduct",
+                          "recommended_instance_type": "p5.48xlarge",
+                          "release_notes": "${RNOTES}",
+                          "root_device": "/dev/sda1",
+                          "scanning_port": 22,
+                          "security_groups": [
+                            {
+                              "from_port": 22,
+                              "ip_protocol": "tcp",
+                              "ip_ranges": [
+                                "0.0.0.0/0"
+                              ],
+                              "to_port": 22
+                            }
+                          ],
+                          "sharing_accounts": [
+                            "111111111111"
+                          ],
+                          "sriov_net_support": "simple",
+                          "usage_instructions": "https://access.redhat.com/articles/xyz",
+                          "user_name": "cloud-user",
+                          "virtualization": "hvm",
+                          "volume": "gp3"
+                        },
+                        "name": "test-product-amd",
+                        "workflow": "stratosphere"
+                      }
+                    ]
+                  }
+                ]
+              }
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: marketplacesvm-push-disk-images
+      params:
+        - name: snapshotPath
+          value: "snapshot_spec.json"
+        - name: cloudMarketplacesSecret
+          value: marketplacesvm-test-secret
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup

--- a/tasks/managed/marketplacesvm-push-disk-images/tests/test-marketplacesvm-push-disk-images.yaml
+++ b/tasks/managed/marketplacesvm-push-disk-images/tests/test-marketplacesvm-push-disk-images.yaml
@@ -313,12 +313,16 @@ spec:
                   cat "$(params.dataDir)/mock_select-oci-auth.txt"
                   exit 1
               fi
-              if [[ $(wc -l < "$(params.dataDir)/mock_oras.txt") != 1 ]]; then
-                  echo "Error: oras was expected to be called a 1 time. Actual calls:"
+              if [[ $(wc -l < "$(params.dataDir)/mock_oras.txt") != 2 ]]; then
+                  echo "Error: oras was expected to be called 2 times (manifest fetch + pull). Actual calls:"
                   cat "$(params.dataDir)/mock_oras.txt"
                   exit 1
-              elif [[ $(<"$(params.dataDir)/mock_oras.txt") != *"$expected_pullspec" ]]; then
-                  echo "Error: oras was expected to be called pullspec $expected_pullspec. Actual: "
+              elif ! grep -q "manifest fetch.*$expected_pullspec" "$(params.dataDir)/mock_oras.txt"; then
+                  echo "Error: oras manifest fetch was expected for $expected_pullspec. Actual:"
+                  cat "$(params.dataDir)/mock_oras.txt"
+                  exit 1
+              elif ! grep -q "pull.*$expected_pullspec" "$(params.dataDir)/mock_oras.txt"; then
+                  echo "Error: oras pull was expected for $expected_pullspec. Actual:"
                   cat "$(params.dataDir)/mock_oras.txt"
                   exit 1
               fi

--- a/tasks/managed/marketplacesvm-push-disk-images/tests/test-marketplacesvm-push-multiarch-disk-images.yaml
+++ b/tasks/managed/marketplacesvm-push-disk-images/tests/test-marketplacesvm-push-multiarch-disk-images.yaml
@@ -2,10 +2,11 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-marketplacesvm-push-disk-images-pre-push
+  name: test-marketplacesvm-push-multiarch-disk-images
 spec:
   description: |
-    Run the marketplacesvm-push-disk-images task in pre-push mode and ensure it succeeds
+    Run the marketplacesvm-push-disk-images task with a multi-arch component containing
+    two architectures (x86_64 and aarch64) to verify per-platform oras pulls.
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -36,8 +37,6 @@ spec:
           - name: workdir
             emptyDir: {}
         stepTemplate:
-          securityContext:
-            runAsUser: 1001
           volumeMounts:
             - mountPath: /var/workdir
               name: workdir
@@ -48,6 +47,8 @@ spec:
               value: "$(params.orasOptions)"
             - name: "DEBUG"
               value: "$(params.trustedArtifactsDebug)"
+          securityContext:
+            runAsUser: 1001
         steps:
           - name: setup
             image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
@@ -61,12 +62,12 @@ spec:
               RNOTES+="instance using ssh\n    * Open an SSH client\n"
               cat > "$(params.dataDir)/snapshot_spec.json" << EOF
               {
-                "application": "amd-bootc-1-3-raw-disk-image",
+                "application": "multiarch-bootc-1-3-raw-disk-image",
                 "artifacts": {},
                 "components": [
                   {
-                    "containerImage": "quay.io/workload/tenant/test-product/amd-bootc-1-3-raw-disk-image@sha256:123456",
-                    "name": "amd-bootc-1-3-raw-disk-image",
+                    "containerImage": "quay.io/workload/tenant/test-product/multiarch-bootc-1-3-raw-disk-image@sha256:123456",
+                    "name": "multiarch-bootc-1-3-raw-disk-image",
                     "source": {
                       "git": {
                         "context": ".",
@@ -84,10 +85,14 @@ spec:
                     },
                     "pushSourceContainer": false,
                     "staged": {
-                      "destination": "test-product-1_DOT_3-x86_64-isos",
+                      "destination": "test-product-1_DOT_3-multi-isos",
                       "files": [
                         {
                           "filename": "test-product-amd-1.3-1732045201-x86_64.raw.gz",
+                          "source": "disk.raw.gz"
+                        },
+                        {
+                          "filename": "test-product-amd-1.3-1732045201-aarch64.raw.gz",
                           "source": "disk.raw.gz"
                         }
                       ],
@@ -104,6 +109,12 @@ spec:
                                 "destination": "00000000-0000-0000-0000-000000000000",
                                 "overwrite": false,
                                 "restrict_version": true
+                              },
+                              {
+                                "architecture": "aarch64",
+                                "destination": "11111111-1111-1111-1111-111111111111",
+                                "overwrite": false,
+                                "restrict_version": true
                               }
                             ],
                             "provider": null
@@ -113,6 +124,12 @@ spec:
                               {
                                 "architecture": "x86_64",
                                 "destination": "ffffffff-ffff-ffff-ffff-ffffffffffff",
+                                "overwrite": false,
+                                "restrict_version": true
+                              },
+                              {
+                                "architecture": "aarch64",
+                                "destination": "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee",
                                 "overwrite": false,
                                 "restrict_version": true
                               }
@@ -154,6 +171,78 @@ spec:
                 ]
               }
               EOF
+
+              cat > "$(params.dataDir)/starmap.json" << EOF
+              [
+                {
+                  "cloud": "aws",
+                  "mappings": {
+                    "aws-emea": {
+                      "destinations": [
+                        {
+                          "architecture": "x86_64",
+                          "destination": "00000000-0000-0000-0000-000000000000",
+                          "overwrite": false,
+                          "restrict_version": true
+                        },
+                        {
+                          "architecture": "aarch64",
+                          "destination": "11111111-1111-1111-1111-111111111111",
+                          "overwrite": false,
+                          "restrict_version": true
+                        }
+                      ],
+                      "provider": null
+                    },
+                    "aws-na": {
+                      "destinations": [
+                        {
+                          "architecture": "x86_64",
+                          "destination": "ffffffff-ffff-ffff-ffff-ffffffffffff",
+                          "overwrite": false,
+                          "restrict_version": true
+                        },
+                        {
+                          "architecture": "aarch64",
+                          "destination": "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee",
+                          "overwrite": false,
+                          "restrict_version": true
+                        }
+                      ],
+                      "provider": null
+                    }
+                  },
+                  "meta": {
+                    "ena_support": true,
+                    "marketplace_entity_type": "AmiProduct",
+                    "recommended_instance_type": "p5.48xlarge",
+                    "release_notes": "${RNOTES}",
+                    "root_device": "/dev/sda1",
+                    "scanning_port": 22,
+                    "security_groups": [
+                      {
+                        "from_port": 22,
+                        "ip_protocol": "tcp",
+                        "ip_ranges": [
+                          "0.0.0.0/0"
+                        ],
+                        "to_port": 22
+                      }
+                    ],
+                    "sharing_accounts": [
+                      "111111111111"
+                    ],
+                    "sriov_net_support": "simple",
+                    "usage_instructions": "https://access.redhat.com/articles/xyz",
+                    "user_name": "cloud-user",
+                    "virtualization": "hvm",
+                    "volume": "gp3"
+                  },
+                  "name": "test-product-amd",
+                  "workflow": "stratosphere"
+                }
+              ]
+              EOF
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact
@@ -172,8 +261,6 @@ spec:
           value: "snapshot_spec.json"
         - name: cloudMarketplacesSecret
           value: marketplacesvm-test-secret
-        - name: prePush
-          value: true
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions
@@ -234,37 +321,82 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
-              # Single component fixture: Expected "prepare_component" to be called once
-              expected_pullspec="quay.io/workload/tenant/test-product/amd-bootc-1-3-raw-disk-image@sha256:123456"
+              STARMAP_EXPECTED_DATA=$(jq -c '.' "$(params.dataDir)/starmap.json")
+              TASK_STARMAP_DATA=$(yq -p yaml -o json < "$(params.dataDir)/starmap.yaml")
+              TASK_STARMAP_DATA=$(jq -c '.' <<< "$TASK_STARMAP_DATA")
+              if [[ "$TASK_STARMAP_DATA" != "$STARMAP_EXPECTED_DATA" ]]; then
+                  echo "Execution failed: Mismatch on expected StArMap data."
+                  echo "Got: $TASK_STARMAP_DATA"
+                  echo "Expected: $STARMAP_EXPECTED_DATA"
+                  exit 1
+              fi
+
+              # Single component fixture: select-oci-auth should be called once
+              expected_pullspec="quay.io/workload/tenant/test-product/multiarch-bootc-1-3-raw-disk-image@sha256:123456"
               if [[ $(wc -l < "$(params.dataDir)/mock_select-oci-auth.txt") != 1 ]]; then
-                  echo "Error: select-oci-auth was expected to be called a 1 time. Actual calls:"
+                  echo "Error: select-oci-auth was expected to be called 1 time. Actual calls:"
                   cat "$(params.dataDir)/mock_select-oci-auth.txt"
                   exit 1
               elif [[ $(<"$(params.dataDir)/mock_select-oci-auth.txt") != "$expected_pullspec" ]]; then
-                  echo "Error: select-oci-auth was expected to be called with $expected_pullspec. Actual: "
+                  echo "Error: select-oci-auth was expected to be called with $expected_pullspec. Actual:"
                   cat "$(params.dataDir)/mock_select-oci-auth.txt"
                   exit 1
               fi
-              if [[ $(wc -l < "$(params.dataDir)/mock_oras.txt") != 2 ]]; then
-                  echo "Error: oras was expected to be called 2 times (manifest fetch + pull). Actual calls:"
+
+              # Multi-arch: expect 3 oras calls (1 manifest fetch + 2 platform-specific pulls)
+              if [[ $(wc -l < "$(params.dataDir)/mock_oras.txt") != 3 ]]; then
+                  echo "Error: oras was expected to be called 3 times (manifest fetch + 2 pulls). Actual calls:"
                   cat "$(params.dataDir)/mock_oras.txt"
                   exit 1
-              elif ! grep -q "manifest fetch.*$expected_pullspec" "$(params.dataDir)/mock_oras.txt"; then
+              fi
+              if ! grep -q "manifest fetch.*$expected_pullspec" "$(params.dataDir)/mock_oras.txt"; then
                   echo "Error: oras manifest fetch was expected for $expected_pullspec. Actual:"
                   cat "$(params.dataDir)/mock_oras.txt"
                   exit 1
-              elif ! grep -q "pull.*$expected_pullspec" "$(params.dataDir)/mock_oras.txt"; then
-                  echo "Error: oras pull was expected for $expected_pullspec. Actual:"
+              fi
+              if ! grep -q "\-\-platform linux/amd64" "$(params.dataDir)/mock_oras.txt"; then
+                  echo "Error: oras pull with --platform linux/amd64 was expected. Actual:"
+                  cat "$(params.dataDir)/mock_oras.txt"
+                  exit 1
+              fi
+              if ! grep -q "\-\-platform linux/arm64" "$(params.dataDir)/mock_oras.txt"; then
+                  echo "Error: oras pull with --platform linux/arm64 was expected. Actual:"
                   cat "$(params.dataDir)/mock_oras.txt"
                   exit 1
               fi
 
+              # Verify each pull ran in its own arch subdirectory, and that the subdirectory
+              # matches the --platform used for that same pull (guards against swapped archs)
+              if [[ $(wc -l < "$(params.dataDir)/mock_oras_workdir.txt") != 2 ]]; then
+                  echo "Error: oras pull was expected to be called 2 times. Actual workdirs:"
+                  cat "$(params.dataDir)/mock_oras_workdir.txt"
+                  exit 1
+              fi
+              if [[ $(sort -u "$(params.dataDir)/mock_oras_workdir.txt" | wc -l) != 2 ]]; then
+                  echo "Error: oras pull was expected to run in 2 distinct subdirectories. Actual workdirs:"
+                  cat "$(params.dataDir)/mock_oras_workdir.txt"
+                  exit 1
+              fi
+              PULL_CALLS=$(grep "^pull --registry-config" "$(params.dataDir)/mock_oras.txt")
+              PULL_WORKDIRS=$(cat "$(params.dataDir)/mock_oras_workdir.txt")
+              PULL_CORRELATION=$(paste -d'|' <(echo "$PULL_CALLS") <(echo "$PULL_WORKDIRS"))
+              if ! grep -q -- "--platform linux/amd64.*|.*/x86_64$" <<< "$PULL_CORRELATION"; then
+                  echo "Error: the linux/amd64 oras pull was expected to run in the x86_64 subdirectory. Actual:"
+                  echo "$PULL_CORRELATION"
+                  exit 1
+              fi
+              if ! grep -q -- "--platform linux/arm64.*|.*/aarch64$" <<< "$PULL_CORRELATION"; then
+                  echo "Error: the linux/arm64 oras pull was expected to run in the aarch64 subdirectory. Actual:"
+                  echo "$PULL_CORRELATION"
+                  exit 1
+              fi
+
               if [[ $(wc -l < "$(params.dataDir)/mock_wrapper.txt") != 1 ]]; then
-                  echo "Error: wrapper was expected to be called a 1 time. Actual calls:"
+                  echo "Error: wrapper was expected to be called 1 time. Actual calls:"
                   cat "$(params.dataDir)/mock_wrapper.txt"
                   exit 1
-              elif [[ $(<"$(params.dataDir)/mock_wrapper.txt") != *"--nochannel"* ]]; then
-                  echo "Error: wrapper was expected to be called with '--nochannel'. Actual call:"
+              elif [[ $(<"$(params.dataDir)/mock_wrapper.txt") == *"--nochannel"* ]]; then
+                  echo "Error: wrapper was expected to be called without '--nochannel'. Actual call:"
                   cat "$(params.dataDir)/mock_wrapper.txt"
                   exit 1
               fi
@@ -284,12 +416,6 @@ spec:
               if [[ "$WRAPPER_ARGS" != *"--source /var/workdir/tmp."* ]]; then
                   echo "Error: BASE_DIR should be under /var/workdir/tmp.*"
                   echo "Actual wrapper args: $WRAPPER_ARGS"
-                  exit 1
-              fi
-              ORAS_WORKDIR=$(<"$(params.dataDir)/mock_oras_workdir.txt")
-              if [[ "$ORAS_WORKDIR" != /var/workdir/tmp.* ]]; then
-                  echo "Error: DOWNLOAD_DIR should be under /var/workdir/tmp.*"
-                  echo "Actual: $ORAS_WORKDIR"
                   exit 1
               fi
 
@@ -320,24 +446,36 @@ spec:
                   exit 1
               fi
 
+              # Verify both architectures are present in pushsource-ls output
+              if ! grep -q "arch='x86_64'" "$PUSHSOURCE_OUTPUT"; then
+                  echo "Error: pushsource-ls output missing x86_64 architecture"
+                  cat "$PUSHSOURCE_OUTPUT"
+                  exit 1
+              fi
+              if ! grep -q "arch='aarch64'" "$PUSHSOURCE_OUTPUT"; then
+                  echo "Error: pushsource-ls output missing aarch64 architecture"
+                  cat "$PUSHSOURCE_OUTPUT"
+                  exit 1
+              fi
+
               STARMAP_NAMES=$(jq -r '[.components[].starmap[].name] | unique | .[]' \
                   "$(params.dataDir)/snapshot_spec.json")
-              BUILD_INFO_NAME=$(grep -oP "KojiBuildInfo\(name='\K[^']*" "$PUSHSOURCE_OUTPUT")
+              BUILD_INFO_NAME=$(grep -oP "KojiBuildInfo\(name='\K[^']*" "$PUSHSOURCE_OUTPUT" | head -1)
               if ! echo "$STARMAP_NAMES" | grep -qx "$BUILD_INFO_NAME"; then
                   echo "Error: build_info.name '$BUILD_INFO_NAME' not found in starmap names:"
                   echo "$STARMAP_NAMES"
                   exit 1
               fi
+
               expected_patterns=(
                   "AmiPushItem"
                   "name='test-product-amd-1\.3-1732045201-x86_64\.raw'"
-                  "src='.*/CLOUD_IMAGES/amd-bootc-1-3-raw-disk-image/test-product-amd-1\.3-1732045201-x86_64\.raw'"
+                  "name='test-product-amd-1\.3-1732045201-aarch64\.raw'"
+                  "src='.*/CLOUD_IMAGES/multiarch-bootc-1-3-raw-disk-image/"
                   "name='test-product-amd'"
                   "version='1\.3'"
                   "respin=1732045201"
-                  # date is derived from BUILD_RESPIN: date -d @1732045201 +%Y%m%d -> 20241119
                   "date=datetime\.date\(2024, 11, 19\)"
-                  "arch='x86_64'"
                   "type='AMI'"
               )
               for pattern in "${expected_patterns[@]}"; do
@@ -349,12 +487,14 @@ spec:
               done
 
               # Verify staged directory contents
-              PUSHSOURCE_SRC=$(grep -oP "src='\\K[^']*" "$PUSHSOURCE_OUTPUT")
-              if ! grep -q "$PUSHSOURCE_SRC" "$STAGED_DIR_OUTPUT" ; then
-                  echo "Error: staged file path does not match pushsource-ls src value."
-                  echo "pushsource-ls src: $PUSHSOURCE_SRC"
+              if ! grep -q "x86_64.raw" "$STAGED_DIR_OUTPUT"; then
+                  echo "Error: staged directory should contain x86_64 raw file"
                   cat "$STAGED_DIR_OUTPUT"
-                  cat "$PUSHSOURCE_OUTPUT"
+                  exit 1
+              fi
+              if ! grep -q "aarch64.raw" "$STAGED_DIR_OUTPUT"; then
+                  echo "Error: staged directory should contain aarch64 raw file"
+                  cat "$STAGED_DIR_OUTPUT"
                   exit 1
               fi
 

--- a/tasks/managed/marketplacesvm-push-disk-images/tests/test-marketplacesvm-push-single-manifest-index.yaml
+++ b/tasks/managed/marketplacesvm-push-disk-images/tests/test-marketplacesvm-push-single-manifest-index.yaml
@@ -2,10 +2,13 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-marketplacesvm-push-disk-images-pre-push
+  name: test-marketplacesvm-push-single-manifest-index
 spec:
   description: |
-    Run the marketplacesvm-push-disk-images task in pre-push mode and ensure it succeeds
+    Run the marketplacesvm-push-disk-images task with a component whose OCI artifact is an
+    image index (application/vnd.oci.image.index.v1+json) that wraps a single manifest. An
+    index mediaType alone does not mean multi-arch, so the task must fall back to a plain
+    oras pull (no --platform) instead of the per-architecture pull loop.
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -36,8 +39,6 @@ spec:
           - name: workdir
             emptyDir: {}
         stepTemplate:
-          securityContext:
-            runAsUser: 1001
           volumeMounts:
             - mountPath: /var/workdir
               name: workdir
@@ -48,6 +49,8 @@ spec:
               value: "$(params.orasOptions)"
             - name: "DEBUG"
               value: "$(params.trustedArtifactsDebug)"
+          securityContext:
+            runAsUser: 1001
         steps:
           - name: setup
             image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
@@ -61,12 +64,12 @@ spec:
               RNOTES+="instance using ssh\n    * Open an SSH client\n"
               cat > "$(params.dataDir)/snapshot_spec.json" << EOF
               {
-                "application": "amd-bootc-1-3-raw-disk-image",
+                "application": "multiarch-single-manifest-bootc-1-3-raw-disk-image",
                 "artifacts": {},
                 "components": [
                   {
-                    "containerImage": "quay.io/workload/tenant/test-product/amd-bootc-1-3-raw-disk-image@sha256:123456",
-                    "name": "amd-bootc-1-3-raw-disk-image",
+                    "containerImage": "quay.io/workload/tenant/test-product/multiarch-single-manifest-bootc-1-3-raw-disk-image@sha256:123456",
+                    "name": "multiarch-single-manifest-bootc-1-3-raw-disk-image",
                     "source": {
                       "git": {
                         "context": ".",
@@ -102,17 +105,6 @@ spec:
                               {
                                 "architecture": "x86_64",
                                 "destination": "00000000-0000-0000-0000-000000000000",
-                                "overwrite": false,
-                                "restrict_version": true
-                              }
-                            ],
-                            "provider": null
-                          },
-                          "aws-na": {
-                            "destinations": [
-                              {
-                                "architecture": "x86_64",
-                                "destination": "ffffffff-ffff-ffff-ffff-ffffffffffff",
                                 "overwrite": false,
                                 "restrict_version": true
                               }
@@ -154,6 +146,55 @@ spec:
                 ]
               }
               EOF
+
+              cat > "$(params.dataDir)/starmap.json" << EOF
+              [
+                {
+                  "cloud": "aws",
+                  "mappings": {
+                    "aws-emea": {
+                      "destinations": [
+                        {
+                          "architecture": "x86_64",
+                          "destination": "00000000-0000-0000-0000-000000000000",
+                          "overwrite": false,
+                          "restrict_version": true
+                        }
+                      ],
+                      "provider": null
+                    }
+                  },
+                  "meta": {
+                    "ena_support": true,
+                    "marketplace_entity_type": "AmiProduct",
+                    "recommended_instance_type": "p5.48xlarge",
+                    "release_notes": "${RNOTES}",
+                    "root_device": "/dev/sda1",
+                    "scanning_port": 22,
+                    "security_groups": [
+                      {
+                        "from_port": 22,
+                        "ip_protocol": "tcp",
+                        "ip_ranges": [
+                          "0.0.0.0/0"
+                        ],
+                        "to_port": 22
+                      }
+                    ],
+                    "sharing_accounts": [
+                      "111111111111"
+                    ],
+                    "sriov_net_support": "simple",
+                    "usage_instructions": "https://access.redhat.com/articles/xyz",
+                    "user_name": "cloud-user",
+                    "virtualization": "hvm",
+                    "volume": "gp3"
+                  },
+                  "name": "test-product-amd",
+                  "workflow": "stratosphere"
+                }
+              ]
+              EOF
           - name: create-trusted-artifact
             ref:
               name: create-trusted-artifact
@@ -172,8 +213,6 @@ spec:
           value: "snapshot_spec.json"
         - name: cloudMarketplacesSecret
           value: marketplacesvm-test-secret
-        - name: prePush
-          value: true
         - name: ociStorage
           value: $(params.ociStorage)
         - name: orasOptions
@@ -234,140 +273,38 @@ spec:
               #!/usr/bin/env bash
               set -eux
 
-              # Single component fixture: Expected "prepare_component" to be called once
-              expected_pullspec="quay.io/workload/tenant/test-product/amd-bootc-1-3-raw-disk-image@sha256:123456"
-              if [[ $(wc -l < "$(params.dataDir)/mock_select-oci-auth.txt") != 1 ]]; then
-                  echo "Error: select-oci-auth was expected to be called a 1 time. Actual calls:"
-                  cat "$(params.dataDir)/mock_select-oci-auth.txt"
-                  exit 1
-              elif [[ $(<"$(params.dataDir)/mock_select-oci-auth.txt") != "$expected_pullspec" ]]; then
-                  echo "Error: select-oci-auth was expected to be called with $expected_pullspec. Actual: "
-                  cat "$(params.dataDir)/mock_select-oci-auth.txt"
-                  exit 1
-              fi
+              expected_pullspec="quay.io/workload/tenant/test-product/multiarch-single-manifest-bootc-1-3-raw-disk-image@sha256:123456"
+
+              # A single-manifest index must be pulled as a single plain oras pull: one
+              # manifest fetch + one pull, with no --platform selection and no per-arch dir.
               if [[ $(wc -l < "$(params.dataDir)/mock_oras.txt") != 2 ]]; then
                   echo "Error: oras was expected to be called 2 times (manifest fetch + pull). Actual calls:"
                   cat "$(params.dataDir)/mock_oras.txt"
                   exit 1
-              elif ! grep -q "manifest fetch.*$expected_pullspec" "$(params.dataDir)/mock_oras.txt"; then
+              fi
+              if ! grep -q "manifest fetch.*$expected_pullspec" "$(params.dataDir)/mock_oras.txt"; then
                   echo "Error: oras manifest fetch was expected for $expected_pullspec. Actual:"
                   cat "$(params.dataDir)/mock_oras.txt"
                   exit 1
-              elif ! grep -q "pull.*$expected_pullspec" "$(params.dataDir)/mock_oras.txt"; then
-                  echo "Error: oras pull was expected for $expected_pullspec. Actual:"
+              fi
+              if ! grep -q "^pull --registry-config.*$expected_pullspec" "$(params.dataDir)/mock_oras.txt"; then
+                  echo "Error: a plain oras pull was expected for $expected_pullspec. Actual:"
                   cat "$(params.dataDir)/mock_oras.txt"
+                  exit 1
+              fi
+              if grep -q -- "--platform" "$(params.dataDir)/mock_oras.txt"; then
+                  echo "Error: oras pull was not expected to use --platform for a single-manifest index. Actual:"
+                  cat "$(params.dataDir)/mock_oras.txt"
+                  exit 1
+              fi
+              if [[ $(wc -l < "$(params.dataDir)/mock_oras_workdir.txt") != 1 ]]; then
+                  echo "Error: oras pull was expected to run once. Actual workdirs:"
+                  cat "$(params.dataDir)/mock_oras_workdir.txt"
                   exit 1
               fi
 
               if [[ $(wc -l < "$(params.dataDir)/mock_wrapper.txt") != 1 ]]; then
-                  echo "Error: wrapper was expected to be called a 1 time. Actual calls:"
+                  echo "Error: wrapper was expected to be called 1 time. Actual calls:"
                   cat "$(params.dataDir)/mock_wrapper.txt"
-                  exit 1
-              elif [[ $(<"$(params.dataDir)/mock_wrapper.txt") != *"--nochannel"* ]]; then
-                  echo "Error: wrapper was expected to be called with '--nochannel'. Actual call:"
-                  cat "$(params.dataDir)/mock_wrapper.txt"
-                  exit 1
-              fi
-
-              # Verify CLOUD_CREDENTIALS is a comma-separated list of JSON file paths
-              CLOUD_CREDS=$(<"$(params.dataDir)/mock_cloud_credentials.txt")
-              EXPECTED_CREDS="/etc/secrets/aws-emea.json,/etc/secrets/aws-na.json"
-              if [[ "$CLOUD_CREDS" != "$EXPECTED_CREDS" ]]; then
-                  echo "Error: CLOUD_CREDENTIALS mismatch."
-                  echo "Expected: $EXPECTED_CREDS"
-                  echo "Actual: $CLOUD_CREDS"
-                  exit 1
-              fi
-
-              # Verify temp directories are created under /var/workdir
-              WRAPPER_ARGS=$(<"$(params.dataDir)/mock_wrapper.txt")
-              if [[ "$WRAPPER_ARGS" != *"--source /var/workdir/tmp."* ]]; then
-                  echo "Error: BASE_DIR should be under /var/workdir/tmp.*"
-                  echo "Actual wrapper args: $WRAPPER_ARGS"
-                  exit 1
-              fi
-              ORAS_WORKDIR=$(<"$(params.dataDir)/mock_oras_workdir.txt")
-              if [[ "$ORAS_WORKDIR" != /var/workdir/tmp.* ]]; then
-                  echo "Error: DOWNLOAD_DIR should be under /var/workdir/tmp.*"
-                  echo "Actual: $ORAS_WORKDIR"
-                  exit 1
-              fi
-
-              # Verify pushsource-ls output && staged directory contents
-              STAGED_DIR_OUTPUT="$(params.dataDir)/mock_staged_dir.txt"
-              PUSHSOURCE_OUTPUT="$(params.dataDir)/mock_pushsource_ls.txt"
-              EXPECTED_RESOURCES_COUNT=$(grep -c "resources.yaml" "$STAGED_DIR_OUTPUT")
-              if [[ "$EXPECTED_RESOURCES_COUNT" != 1 ]]; then
-                  echo "Error: resources.yaml should appear exactly once. Found: $EXPECTED_RESOURCES_COUNT"
-                  cat "$STAGED_DIR_OUTPUT"
-                  cat "$PUSHSOURCE_OUTPUT"
-                  exit 1
-              fi
-
-              EXPECTED_ITEMS=$(jq '[.components[].staged.files | length] | add' \
-                  "$(params.dataDir)/snapshot_spec.json")
-              if ! grep -q "# ${EXPECTED_ITEMS} item(s) found in source" "$PUSHSOURCE_OUTPUT"; then
-                  echo "Error: pushsource-ls should find ${EXPECTED_ITEMS} item(s). Actual output:"
-                  cat "$STAGED_DIR_OUTPUT"
-                  cat "$PUSHSOURCE_OUTPUT"
-                  exit 1
-              fi
-
-              AMI_PI_COUNT=$(grep -c "AmiPushItem" "$PUSHSOURCE_OUTPUT")
-              if [[ "$AMI_PI_COUNT" != "$EXPECTED_ITEMS" ]]; then
-                  echo "Error: AmiPushItem should appear ${EXPECTED_ITEMS} time(s). Found: $AMI_PI_COUNT"
-                  cat "$PUSHSOURCE_OUTPUT"
-                  exit 1
-              fi
-
-              STARMAP_NAMES=$(jq -r '[.components[].starmap[].name] | unique | .[]' \
-                  "$(params.dataDir)/snapshot_spec.json")
-              BUILD_INFO_NAME=$(grep -oP "KojiBuildInfo\(name='\K[^']*" "$PUSHSOURCE_OUTPUT")
-              if ! echo "$STARMAP_NAMES" | grep -qx "$BUILD_INFO_NAME"; then
-                  echo "Error: build_info.name '$BUILD_INFO_NAME' not found in starmap names:"
-                  echo "$STARMAP_NAMES"
-                  exit 1
-              fi
-              expected_patterns=(
-                  "AmiPushItem"
-                  "name='test-product-amd-1\.3-1732045201-x86_64\.raw'"
-                  "src='.*/CLOUD_IMAGES/amd-bootc-1-3-raw-disk-image/test-product-amd-1\.3-1732045201-x86_64\.raw'"
-                  "name='test-product-amd'"
-                  "version='1\.3'"
-                  "respin=1732045201"
-                  # date is derived from BUILD_RESPIN: date -d @1732045201 +%Y%m%d -> 20241119
-                  "date=datetime\.date\(2024, 11, 19\)"
-                  "arch='x86_64'"
-                  "type='AMI'"
-              )
-              for pattern in "${expected_patterns[@]}"; do
-                  if ! grep -qE "$pattern" "$PUSHSOURCE_OUTPUT"; then
-                      echo "Error: pushsource-ls output missing expected pattern: $pattern"
-                      cat "$PUSHSOURCE_OUTPUT"
-                      exit 1
-                  fi
-              done
-
-              # Verify staged directory contents
-              PUSHSOURCE_SRC=$(grep -oP "src='\\K[^']*" "$PUSHSOURCE_OUTPUT")
-              if ! grep -q "$PUSHSOURCE_SRC" "$STAGED_DIR_OUTPUT" ; then
-                  echo "Error: staged file path does not match pushsource-ls src value."
-                  echo "pushsource-ls src: $PUSHSOURCE_SRC"
-                  cat "$STAGED_DIR_OUTPUT"
-                  cat "$PUSHSOURCE_OUTPUT"
-                  exit 1
-              fi
-
-              # Verify wrapper artifacts were collected
-              ARTIFACTS_DIR="$(params.dataDir)/artifacts"
-              if [[ ! -d "$ARTIFACTS_DIR" ]]; then
-                  echo "Error: artifacts directory not found at $ARTIFACTS_DIR"
-                  ls -laR "$(params.dataDir)"
-                  exit 1
-              fi
-              ARTIFACTS_COUNT=$(find "$ARTIFACTS_DIR" -name "clouds.json" | wc -l)
-              if [[ "$ARTIFACTS_COUNT" -ne 1 ]]; then
-                  echo "Error: expected 1 clouds.json in artifacts, found: $ARTIFACTS_COUNT"
-                  find "$ARTIFACTS_DIR" -type f
                   exit 1
               fi


### PR DESCRIPTION
## Describe your changes

Detect multi-arch images via oras manifest fetch and issue per-architecture oras pull --platform calls into separate subdirectories, preventing identically named layers from overwriting each other. Single-arch images keep existing behavior unchanged.

Assisted-by: Claude

## Relevant Jira

RELEASE-2758

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
