### PR TITLE
fix: push-to-addons-registry test arch check order

### DIFF
--- a/integration-tests/push-to-addons-registry/test.sh
+++ b/integration-tests/push-to-addons-registry/test.sh
@@ -248,7 +248,7 @@ verify_release_contents() {
     echo ""
     echo "Verifying arches and skopeo pullability for each image..."
 
-    for i in 0 1; do
+    for i in $(seq 0 $((image_count - 1))); do
         local img_url img_shasum img_arches
         img_url=$(jq -r --argjson idx "$i" '.status.artifacts.images[$idx]?.urls[0] // ""' <<< "${release_json}")
         img_shasum=$(jq -r --argjson idx "$i" '.status.artifacts.images[$idx]?.shasum // ""' <<< "${release_json}")
@@ -256,6 +256,11 @@ verify_release_contents() {
           | map((tostring | split("/") | .[-1]))
           | unique
           | join(" ")' <<< "${release_json}")
+
+        local is_single_arch=0
+        if [[ "${img_url}" == *"component2"* ]]; then
+            is_single_arch=1
+        fi
 
         echo ""
         echo "Image ${i}: url=${img_url}, shasum=${img_shasum}, arches=${img_arches}"
@@ -266,7 +271,7 @@ verify_release_contents() {
             continue
         fi
 
-        if [ "$i" -eq 0 ]; then
+        if [ "${is_single_arch}" -eq 0 ]; then
             echo "Checking image ${i} arches include amd64 and arm64..."
             if [[ " ${img_arches} " == *" amd64 "* && " ${img_arches} " == *" arm64 "* ]]; then
                 echo "✅️ Image ${i} has required arches: ${img_arches}"
@@ -295,7 +300,7 @@ verify_release_contents() {
         echo "Verifying image ${i} pullability with skopeo..."
         if [[ "${img_shasum}" == sha256:* ]]; then
             set +e
-            if [ "$i" -eq 0 ]; then
+            if [ "${is_single_arch}" -eq 0 ]; then
                 "${SCRIPT_DIR}/scripts/skopeo-verify-image.sh" \
                     "${img_url}" "${img_shasum}" \
                     "${SUITE_DIR}/resources/managed/secrets/managed-secrets.yaml" \


### PR DESCRIPTION
## Describe your changes

Image order in .status.artifacts.images is
non-deterministic. Match by component name in the
image URL to apply correct arch checks.

Assisted-by: Claude Code

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [x] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
