### PR TITLE
fix(RELEASE-2747): symlink extraction in push-artifacts-to-cdn

### DIFF
--- a/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
@@ -179,7 +179,7 @@ spec:
 
   steps:
     - name: push-artifacts-to-cdn
-      image: quay.io/konflux-ci/release-service-utils@sha256:f88c25bacfd8575198419a8465804980ba6531dfb2b4717a7ebc4415df43910d
+      image: quay.io/konflux-ci/release-service-utils@sha256:a542fa62dc02d485cb0509d6319b566ef8c0db41598f6ce1ffc140e1c9679b57
       securityContext:
         runAsUser: 1001
       computeResources:

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/test-push-artifacts-to-cdn.yaml
@@ -59,7 +59,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:3d55e1ab6d2d56870f6c1e45c3f50af6bd9f90a52454419307ca1b0c51df594a
+            image: quay.io/konflux-ci/release-service-utils@sha256:a542fa62dc02d485cb0509d6319b566ef8c0db41598f6ce1ffc140e1c9679b57
             script: |
               #!/usr/bin/env bash
               set -ex


### PR DESCRIPTION
This commit bumps the image used in the push-artifacts-to-cdn-task internal task to fix a bug that all sym links in the extracted directory tree were rejected instead of just the ones part of `wanted_files`.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
