### PR TITLE
fix(CALUNGA-292): switching signature verification to use classic chains

### DIFF
--- a/pipelines/managed/calunga-push-npm-to-pulp/calunga-push-npm-to-pulp.yaml
+++ b/pipelines/managed/calunga-push-npm-to-pulp/calunga-push-npm-to-pulp.yaml
@@ -182,6 +182,19 @@ spec:
               {"resultIndex": 4, "key": ".pulp.secretName", "default": "rhtl-pulp-credentials-secret"}
             ]
 
+    - name: collect-signing-params
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/collect-signing-params/collect-signing-params.yaml
+      runAfter:
+        - collect-data
+
     - name: reduce-snapshot
       taskRef:
         resolver: "git"
@@ -242,15 +255,24 @@ spec:
         - name: STRICT
           value: "true"
         - name: IGNORE_REKOR
-          value: "false"
+          value: "true"
         - name: EXTRA_RULE_DATA
           value: $(params.enterpriseContractExtraRuleData)
         - name: SOURCE_DATA_ARTIFACT
           value: "$(tasks.reduce-snapshot.results.sourceDataArtifact)"
+        - name: CERTIFICATE_IDENTITY
+          value: "$(tasks.collect-signing-params.results.tektonChainsIdentity)"
+        - name: CERTIFICATE_OIDC_ISSUER
+          value: "$(tasks.collect-signing-params.results.defaultOIDCIssuer)"
+        - name: TUF_MIRROR
+          value: "$(tasks.collect-signing-params.results.tufUrl)"
+        - name: REKOR_HOST
+          value: "$(tasks.collect-signing-params.results.rekorUrl)"
         - name: TRUSTED_ARTIFACTS_DEBUG
           value: "$(params.trustedArtifactsDebug)"
       runAfter:
         - reduce-snapshot
+        - collect-signing-params
 
     - name: extract-npm-artifacts
       taskRef:


### PR DESCRIPTION


Assisted by: Cursor 3.5.53

## Describe your changes
Wire collect-signing-params into npm Pulp release pipeline so verify-conforma can validate Chains cosign signatures (parity with Python calunga-push-to-pulp)

## Relevant Jira
https://redhat.atlassian.net/browse/CALUNGA-292

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [x] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
