### PR TITLE
fix(KONFLUX-13766): double-quote version strings in advisory YAML

### DIFF
--- a/tasks/internal/create-advisory-task/create-advisory-task.yaml
+++ b/tasks/internal/create-advisory-task/create-advisory-task.yaml
@@ -86,7 +86,7 @@ spec:
       runAsUser: 1001
   steps:
     - name: create-advisory
-      image: quay.io/konflux-ci/release-service-utils@sha256:71a99d12d920fcc157e08e5dc9894fbc4bce42328e9c2f58dc53411278858d91
+      image: quay.io/konflux-ci/release-service-utils@sha256:521d3f581997bbea5f1e4bc676a6cb4e8c2a7925445f6c4dbf0b07c018c40ef7
       computeResources:
         limits:
           memory: 512Mi

--- a/tasks/internal/create-advisory-task/tests/test-create-advisory.yaml
+++ b/tasks/internal/create-advisory-task/tests/test-create-advisory.yaml
@@ -50,7 +50,7 @@ spec:
             type: string
         steps:
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:71a99d12d920fcc157e08e5dc9894fbc4bce42328e9c2f58dc53411278858d91
+            image: quay.io/konflux-ci/release-service-utils@sha256:521d3f581997bbea5f1e4bc676a6cb4e8c2a7925445f6c4dbf0b07c018c40ef7
             script: |
               #!/usr/bin/env bash
               set -eux


### PR DESCRIPTION

## Describe your changes
Update the create-advisory-task image digests.

PyYAML writes "9.9" or "1" as float/int without quotes and writes "1.0.1" without quotes as it's not ambiguous. Added a custom dumper to force double quotes on all values like these for consistency across advisories. int/bool fields are not affected.

## Relevant Jira
Depends on: https://github.com/konflux-ci/release-service-utils/pull/942
Jira: https://redhat.atlassian.net/browse/KONFLUX-13766

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
