### PR TITLE
chore: enable Jira updates by default in promote workflow

### DIFF
--- a/.github/workflows/promote_branch.yaml
+++ b/.github/workflows/promote_branch.yaml
@@ -42,9 +42,8 @@ on:
         type: boolean
         required: true
         default: false
-      update-jira-tickets:
-        description: |
-          Update Jira tickets: Update Jira tickets that have been promoted
+      skip-jira-updates:
+        description: Skip Jira ticket updates after promotion
         type: boolean
         required: true
         default: false
@@ -73,7 +72,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
         with:
           fetch-depth: 0  # Fetch full history for commit analysis
-      
+
       - name: Capture commits for report (if email report requested)
         if: inputs.send-email-report == true
         id: capture-commits
@@ -86,31 +85,31 @@ jobs:
             FROM_BRANCH="staging"
             TO_BRANCH="production"
           fi
-          
+
           # Fetch latest remote state
           git fetch --no-tags origin
-          
+
           # Get commit range and store in file for later use
           echo "FROM_BRANCH=$FROM_BRANCH" >> $GITHUB_ENV
           echo "TO_BRANCH=$TO_BRANCH" >> $GITHUB_ENV
-          
+
           # Capture the commit range before promotion
           COMMIT_RANGE="origin/$TO_BRANCH..origin/$FROM_BRANCH"
           echo "COMMIT_RANGE=$COMMIT_RANGE" >> $GITHUB_ENV
-          
+
           # Get commit hashes and store them
           COMMITS=$(git log --pretty=format:"%H" $COMMIT_RANGE | head -50)
           echo "COMMITS<<EOF" >> $GITHUB_ENV
           echo "$COMMITS" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
-          
+
           # Store commits in a file for manual recovery
           echo "$COMMITS" > /tmp/promoted_commits.txt
-          
+
           # Also capture the current HEAD of source branch for reference
           SOURCE_HEAD=$(git rev-parse origin/$FROM_BRANCH)
           echo "SOURCE_HEAD=$SOURCE_HEAD" >> $GITHUB_ENV
-          
+
           echo "📊 Captured $(echo "$COMMITS" | wc -l) commits for report generation"
           echo "📊 Source branch HEAD: $SOURCE_HEAD"
 
@@ -182,7 +181,7 @@ jobs:
             done
 
             STATUS=""
-            # wait for the run status 
+            # wait for the run status
             while [ "$STATUS" != "completed" ]; do
               STATUS=$(curl "${GH_ACTIONS_URL}/runs/$ID" |jq -r .status)
               sleep 1
@@ -198,8 +197,8 @@ jobs:
           fi
       - name: Update Jira ticket(s)
         if: |
-          steps.promote.outcome == 'success' && 
-          inputs.update-jira-tickets == true &&
+          steps.promote.outcome == 'success' &&
+          inputs.skip-jira-updates == false &&
           inputs.dry-run == false &&
           steps.promote.outputs.parsed_tickets_file != ''
         env:
@@ -242,40 +241,40 @@ jobs:
             echo "WARNING: Jira Automation webhook returned HTTP ${HTTP_CODE}"
             echo "Promotion was successful but Jira update may have failed."
           fi
-          
+
       - name: Set up Python
         if: |
-          steps.promote.outcome == 'success' && 
+          steps.promote.outcome == 'success' &&
           inputs.send-email-report == true
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7
         with:
           python-version: '3.11'
-      
+
       - name: Install dependencies
         if: |
-          steps.promote.outcome == 'success' && 
+          steps.promote.outcome == 'success' &&
           inputs.send-email-report == true
         run: |
           python -m pip install --upgrade pip
           pip install requests pyyaml markdown google-generativeai
-      
+
       - name: Generate promotion report
         if: |
-          steps.promote.outcome == 'success' && 
+          steps.promote.outcome == 'success' &&
           inputs.send-email-report == true
         id: generate-report
         continue-on-error: true
         run: |
           # Create secret files securely
           echo "${{ secrets.GEMINI_API_KEY }}" > /tmp/gemini_api_key
-          echo "${{ secrets.SMTP_USERNAME }}" > /tmp/smtp_username  
+          echo "${{ secrets.SMTP_USERNAME }}" > /tmp/smtp_username
           echo "${{ secrets.SMTP_PASSWORD }}" > /tmp/smtp_password
           echo "${{ secrets.GH_TOKEN }}" > /tmp/gh_token
           chmod 600 /tmp/gemini_api_key /tmp/smtp_username /tmp/smtp_password /tmp/gh_token
-          
+
           # Generate the promotion report using captured commit range
           python .github/scripts/generate_promotion_report.py $FROM_BRANCH $TO_BRANCH --commit-range "$COMMIT_RANGE"
-          
+
           # Clean up secret files
           rm -f /tmp/gemini_api_key /tmp/smtp_username /tmp/smtp_password /tmp/gh_token
         env:
@@ -289,7 +288,7 @@ jobs:
           SMTP_USERNAME_FILE: /tmp/smtp_username
           SMTP_PASSWORD_FILE: /tmp/smtp_password
           GH_TOKEN_FILE: /tmp/gh_token
-      
+
       - name: Report generation status
         if: always() && inputs.send-email-report == true
         run: |


### PR DESCRIPTION


## Describe your changes
Rename input from update-jira-tickets to skip-jira-updates so Jira updates run on every successful promotion unless opted out.
## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
