### PR TITLE
feat(RELEASE-2774): Fix IR fetching in push-disk-images

### DIFF
--- a/tasks/managed/push-disk-images/push-disk-images.yaml
+++ b/tasks/managed/push-disk-images/push-disk-images.yaml
@@ -194,7 +194,7 @@ spec:
                          | tee "$IR_RESULT_FILE"
 
         set +x
-        internalRequest=$(awk 'NR==1{ print $2 }' "$IR_RESULT_FILE" | xargs)
+        internalRequest=$(grep "^InternalRequest " "$IR_RESULT_FILE" | awk '{ print $2 }' | tr -d "'")
         echo "done (${internalRequest})"
 
         results=$(kubectl get internalrequest "$internalRequest" -o=jsonpath='{.status.results}')


### PR DESCRIPTION
The managed `push-disk-images` task extracts the InternalRequest name from `internal-request` stdout by blindly taking the second word of the first line which could be unrelated "log" message. This PR fixes fetching internal request name from the IR result


Assisted-By: claude

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
