### PR TITLE
fix(CALUNGA-292): Updating npm utils image with slsa 0.2 support

### DIFF
--- a/tasks/managed/extract-npm-artifacts/extract-npm-artifacts.yaml
+++ b/tasks/managed/extract-npm-artifacts/extract-npm-artifacts.yaml
@@ -117,7 +117,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: extract
-      image: quay.io/redhat-user-workloads/calunga-tenant/plumbing-utils@sha256:9e1b3d30dc05413b1d499a19f7b7ca38469098845b50a337f1c3170918efe987
+      image: quay.io/redhat-user-workloads/calunga-tenant/plumbing-utils@sha256:7a70b948126da4daf5f6e7b493310043b9695ae9faa1071f4bfff023ab12d85f
       computeResources:
         limits:
           memory: 256Mi

--- a/tasks/managed/upload-npm-pulp/upload-npm-pulp.yaml
+++ b/tasks/managed/upload-npm-pulp/upload-npm-pulp.yaml
@@ -130,7 +130,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: upload
-      image: quay.io/redhat-user-workloads/calunga-tenant/plumbing-utils@sha256:9e1b3d30dc05413b1d499a19f7b7ca38469098845b50a337f1c3170918efe987
+      image: quay.io/redhat-user-workloads/calunga-tenant/plumbing-utils@sha256:7a70b948126da4daf5f6e7b493310043b9695ae9faa1071f4bfff023ab12d85f
       volumeMounts:
         - name: service-account-secret
           mountPath: "/etc/service-account-secret"


### PR DESCRIPTION
## Describe your changes
While extracting the npm artifacts from quay we are only supporting salsa 1 while we are also getting artifacts with v0.2 provenance. This new version of utils supports both v1 and v0.2

## Relevant Jira
https://redhat.atlassian.net/browse/CALUNGA-292

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [x] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
