### PR TITLE
fix(CALUNGA-292): bump npm utils image with pulp upload fix

### DIFF
--- a/tasks/managed/extract-npm-artifacts/extract-npm-artifacts.yaml
+++ b/tasks/managed/extract-npm-artifacts/extract-npm-artifacts.yaml
@@ -117,7 +117,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: extract
-      image: quay.io/redhat-user-workloads/calunga-tenant/plumbing-utils@sha256:7a70b948126da4daf5f6e7b493310043b9695ae9faa1071f4bfff023ab12d85f
+      image: quay.io/redhat-user-workloads/calunga-tenant/plumbing-utils@sha256:4d8a0c051956f5ea4afcb7bdb0382372c34e0f1fece761e2e2bb2b4c45a516a2
       computeResources:
         limits:
           memory: 256Mi

--- a/tasks/managed/upload-npm-pulp/tests/mocks.sh
+++ b/tasks/managed/upload-npm-pulp/tests/mocks.sh
@@ -77,7 +77,8 @@ function curl() {
 
   # Repository list / refresh (match URL path, not repository_version= query values)
   if [[ "${joined}" == *"/repositories/npm/npm/"* \
-     && "${joined}" != *"/content/"* ]]; then
+     && "${joined}" != *"/content/"* \
+     && "${joined}" != *"modify/"* ]]; then
     local ver
     ver="$(_mock_version)"
     jq -nc --argjson ver "${ver}" '{
@@ -131,6 +132,18 @@ function curl() {
       && mv "${MOCK_PULP_STATE}.tmp" "${MOCK_PULP_STATE}"
     _bump_version
     echo '{"pulp_href":"/api/pulp/test-domain/api/v3/content/npm/packages/uploaded/"}'
+    return 0
+  fi
+
+  # Add uploaded content to the repository (async task)
+  if [[ "${joined}" == *"modify/"* ]]; then
+    _bump_version
+    echo '{"task":"/api/pulp/test-domain/api/v3/tasks/task-uuid/"}'
+    return 0
+  fi
+
+  if [[ "${joined}" == *"/tasks/"* ]]; then
+    echo '{"state":"completed"}'
     return 0
   fi
 
@@ -226,18 +239,27 @@ function curl() {
     return 0
   fi
 
-  # Content list / existence
+  # Content list / existence. RH Pulp has no version= filter; the client
+  # lists by name and filters version in jq. Keep version= lookup so the
+  # currently pinned plumbing-utils image still works.
   if [[ "${joined}" == *"/content/npm/packages/"* ]]; then
     local name version key entry
     name="$(_arg_value name "${args[@]}" || true)"
     version="$(_arg_value version "${args[@]}" || true)"
-    key="$(_pkg_key "${name}" "${version}")"
-    entry="$(jq -c --arg key "${key}" '.[$key] // empty' "${MOCK_PULP_STATE}")"
-    if [[ -z "${entry}" ]]; then
-      echo '{"count":0,"results":[]}'
+    if [[ -n "${version}" ]]; then
+      key="$(_pkg_key "${name}" "${version}")"
+      entry="$(jq -c --arg key "${key}" '.[$key] // empty' "${MOCK_PULP_STATE}")"
+      if [[ -z "${entry}" ]]; then
+        echo '{"count":0,"next":null,"results":[]}'
+        return 0
+      fi
+      jq -nc --argjson entry "${entry}" '{count:1, next:null, results:[$entry]}'
       return 0
     fi
-    jq -nc --argjson entry "${entry}" '{count:1, results:[$entry]}'
+    jq -nc --arg name "${name}" --slurpfile state "${MOCK_PULP_STATE}" '
+      ($state[0] | to_entries | map(.value) | map(select(.name == $name))) as $r
+      | {count: ($r | length), next: null, results: $r}
+    '
     return 0
   fi
 

--- a/tasks/managed/upload-npm-pulp/upload-npm-pulp.yaml
+++ b/tasks/managed/upload-npm-pulp/upload-npm-pulp.yaml
@@ -130,7 +130,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: upload
-      image: quay.io/redhat-user-workloads/calunga-tenant/plumbing-utils@sha256:7a70b948126da4daf5f6e7b493310043b9695ae9faa1071f4bfff023ab12d85f
+      image: quay.io/redhat-user-workloads/calunga-tenant/plumbing-utils@sha256:4d8a0c051956f5ea4afcb7bdb0382372c34e0f1fece761e2e2bb2b4c45a516a2
       volumeMounts:
         - name: service-account-secret
           mountPath: "/etc/service-account-secret"


### PR DESCRIPTION
Assisted by cursor 3.15.6

## Describe your changes
Bumping the image for npm utils with new fix for npm pulp upload. Also enhancing the testing around upload.

## Relevant Jira
https://redhat.atlassian.net/browse/CALUNGA-292

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [x] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
