### PR TITLE
chore: remove ralph from codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,6 @@
 # Code owners for specific directories only
 # Other directories follow default repo PR approval settings
 
-/pipelines/ @gbenhaim @ralphbean @twaugh @davidmogar @johnbieren
-/tasks/ @gbenhaim @ralphbean @twaugh @davidmogar @johnbieren
-/stepactions/ @gbenhaim @ralphbean @twaugh @davidmogar @johnbieren
+/pipelines/ @gbenhaim @twaugh @davidmogar @johnbieren
+/tasks/ @gbenhaim @twaugh @davidmogar @johnbieren
+/stepactions/ @gbenhaim @twaugh @davidmogar @johnbieren


### PR DESCRIPTION
He is working on fullsend now instead of focusing on konflux.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
