### PR TITLE
fix: bump release-service-utils image for cdn push

### DIFF
--- a/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
@@ -179,7 +179,7 @@ spec:
 
   steps:
     - name: push-artifacts-to-cdn
-      image: quay.io/konflux-ci/release-service-utils@sha256:f88c25bacfd8575198419a8465804980ba6531dfb2b4717a7ebc4415df43910d
+      image: quay.io/konflux-ci/release-service-utils@sha256:d3bb0f5a3ff85e30de88cb65953811bb34cc003942750dfc2f97b37a8915726b
       securityContext:
         runAsUser: 1001
       computeResources:

--- a/tasks/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
@@ -132,7 +132,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: run-script
-      image: quay.io/konflux-ci/release-service-utils@sha256:f88c25bacfd8575198419a8465804980ba6531dfb2b4717a7ebc4415df43910d
+      image: quay.io/konflux-ci/release-service-utils@sha256:d3bb0f5a3ff85e30de88cb65953811bb34cc003942750dfc2f97b37a8915726b
       computeResources:
         limits:
           memory: 512Mi


### PR DESCRIPTION
Bump the release-service-utils image digest in both the push-artifacts-to-cdn task and the internal push-artifacts-to-cdn-task to pick up konflux-ci/release-service-utils#972, which removes the invalid Pulp include_repos search property that broke staging, and surfaces the real failing phase and exception in the Tekton result.

Assisted-by: Cursor AI

Assisted-by: Cursor AI

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
