### PR TITLE
fix: bump release-service-utils image in direct signing tasks

### DIFF
--- a/tasks/managed/direct-sign-index-image/direct-sign-index-image.yaml
+++ b/tasks/managed/direct-sign-index-image/direct-sign-index-image.yaml
@@ -167,7 +167,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: direct-sign-index-image
-      image: quay.io/konflux-ci/release-service-utils@sha256:7720dd1fcce6163cd9204c545297ac1ba18bbc39b5e19787d6fb165c835b1354
+      image: quay.io/konflux-ci/release-service-utils@sha256:9db0cc6b09799f41c87d46589dcd2c1ba66edfcaab3b88b99e2fcbc0646424bf
       computeResources:
         limits:
           memory: 1Gi

--- a/tasks/managed/direct-sign-index-image/tests/test-direct-sign-index-image.yaml
+++ b/tasks/managed/direct-sign-index-image/tests/test-direct-sign-index-image.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:7720dd1fcce6163cd9204c545297ac1ba18bbc39b5e19787d6fb165c835b1354
+            image: quay.io/konflux-ci/release-service-utils@sha256:9db0cc6b09799f41c87d46589dcd2c1ba66edfcaab3b88b99e2fcbc0646424bf
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -148,7 +148,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:7720dd1fcce6163cd9204c545297ac1ba18bbc39b5e19787d6fb165c835b1354
+            image: quay.io/konflux-ci/release-service-utils@sha256:9db0cc6b09799f41c87d46589dcd2c1ba66edfcaab3b88b99e2fcbc0646424bf
             script: |
               #!/usr/bin/env bash
               set -euxo pipefail

--- a/tasks/managed/rh-direct-sign-image/rh-direct-sign-image.yaml
+++ b/tasks/managed/rh-direct-sign-image/rh-direct-sign-image.yaml
@@ -174,7 +174,7 @@ spec:
           value: $(params.sourceDataArtifact)
 
     - name: sign-image
-      image: quay.io/konflux-ci/release-service-utils@sha256:7720dd1fcce6163cd9204c545297ac1ba18bbc39b5e19787d6fb165c835b1354
+      image: quay.io/konflux-ci/release-service-utils@sha256:9db0cc6b09799f41c87d46589dcd2c1ba66edfcaab3b88b99e2fcbc0646424bf
       computeResources:
         limits:
           memory: 4Gi

--- a/tasks/managed/rh-direct-sign-image/tests/test-rh-direct-sign-image.yaml
+++ b/tasks/managed/rh-direct-sign-image/tests/test-rh-direct-sign-image.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:7720dd1fcce6163cd9204c545297ac1ba18bbc39b5e19787d6fb165c835b1354
+            image: quay.io/konflux-ci/release-service-utils@sha256:9db0cc6b09799f41c87d46589dcd2c1ba66edfcaab3b88b99e2fcbc0646424bf
             script: |
               #!/usr/bin/env bash
               set -euxo pipefail
@@ -161,7 +161,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:7720dd1fcce6163cd9204c545297ac1ba18bbc39b5e19787d6fb165c835b1354
+            image: quay.io/konflux-ci/release-service-utils@sha256:9db0cc6b09799f41c87d46589dcd2c1ba66edfcaab3b88b99e2fcbc0646424bf
             script: |
               #!/usr/bin/env bash
               set -euxo pipefail


### PR DESCRIPTION
## Summary

- Bumps `release-service-utils` image to `sha256:9db0cc6b09799f41c87d46589dcd2c1ba66edfcaab3b88b99e2fcbc0646424bf` in `rh-direct-sign-image` and `direct-sign-index-image` tasks and their tests
- This new image reverts the cleanup feature that was accidentally deleting signing internal requests

## Test plan

- [ ] Verify `rh-direct-sign-image` task tests pass
- [ ] Verify `direct-sign-index-image` task tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)