### PR TITLE
fix: revert KONFLUX-13012

### DIFF
--- a/tasks/managed/direct-sign-index-image/direct-sign-index-image.yaml
+++ b/tasks/managed/direct-sign-index-image/direct-sign-index-image.yaml
@@ -167,7 +167,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: direct-sign-index-image
-      image: quay.io/konflux-ci/release-service-utils@sha256:7720dd1fcce6163cd9204c545297ac1ba18bbc39b5e19787d6fb165c835b1354
+      image: quay.io/konflux-ci/release-service-utils@sha256:9db0cc6b09799f41c87d46589dcd2c1ba66edfcaab3b88b99e2fcbc0646424bf
       computeResources:
         limits:
           memory: 1Gi

--- a/tasks/managed/direct-sign-index-image/tests/test-direct-sign-index-image.yaml
+++ b/tasks/managed/direct-sign-index-image/tests/test-direct-sign-index-image.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:7720dd1fcce6163cd9204c545297ac1ba18bbc39b5e19787d6fb165c835b1354
+            image: quay.io/konflux-ci/release-service-utils@sha256:9db0cc6b09799f41c87d46589dcd2c1ba66edfcaab3b88b99e2fcbc0646424bf
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -148,7 +148,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:7720dd1fcce6163cd9204c545297ac1ba18bbc39b5e19787d6fb165c835b1354
+            image: quay.io/konflux-ci/release-service-utils@sha256:9db0cc6b09799f41c87d46589dcd2c1ba66edfcaab3b88b99e2fcbc0646424bf
             script: |
               #!/usr/bin/env bash
               set -euxo pipefail

--- a/tasks/managed/rh-direct-sign-image/rh-direct-sign-image.yaml
+++ b/tasks/managed/rh-direct-sign-image/rh-direct-sign-image.yaml
@@ -174,7 +174,7 @@ spec:
           value: $(params.sourceDataArtifact)
 
     - name: sign-image
-      image: quay.io/konflux-ci/release-service-utils@sha256:7720dd1fcce6163cd9204c545297ac1ba18bbc39b5e19787d6fb165c835b1354
+      image: quay.io/konflux-ci/release-service-utils@sha256:9db0cc6b09799f41c87d46589dcd2c1ba66edfcaab3b88b99e2fcbc0646424bf
       computeResources:
         limits:
           memory: 4Gi

--- a/tasks/managed/rh-direct-sign-image/tests/test-rh-direct-sign-image.yaml
+++ b/tasks/managed/rh-direct-sign-image/tests/test-rh-direct-sign-image.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:7720dd1fcce6163cd9204c545297ac1ba18bbc39b5e19787d6fb165c835b1354
+            image: quay.io/konflux-ci/release-service-utils@sha256:9db0cc6b09799f41c87d46589dcd2c1ba66edfcaab3b88b99e2fcbc0646424bf
             script: |
               #!/usr/bin/env bash
               set -euxo pipefail
@@ -161,7 +161,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:7720dd1fcce6163cd9204c545297ac1ba18bbc39b5e19787d6fb165c835b1354
+            image: quay.io/konflux-ci/release-service-utils@sha256:9db0cc6b09799f41c87d46589dcd2c1ba66edfcaab3b88b99e2fcbc0646424bf
             script: |
               #!/usr/bin/env bash
               set -euxo pipefail


### PR DESCRIPTION
This commit reverts to release-service-utils image after applied Revert "fix(KONFLUX-13012): clean up orphan IRs before creating new one

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
