### PR TITLE
fix: pin blob-signing pipeline image to non-expiring tag

### DIFF
--- a/pipelines/internal/blob-signing-pipeline/README.md
+++ b/pipelines/internal/blob-signing-pipeline/README.md
@@ -4,11 +4,11 @@ Tekton pipeline for signing base64 blobs
 
 ## Parameters
 
-| Name            | Description                                                                           | Optional | Default value                                                                         |
-|-----------------|---------------------------------------------------------------------------------------|----------|---------------------------------------------------------------------------------------|
-| pipeline_image  | An image with CLI tools needed for the signing                                        | Yes      | quay.io/redhat-isv/operator-pipelines-images:9ea90b42456fcdf66edf4b15c0c0487ba5fa3ee3 |
-| blob            | Blob that needs to be signed                                                          | No       | -                                                                                     |
-| requester       | Name of the user that requested the signing, for auditing purposes                    | No       | -                                                                                     |
-| config_map_name | A config map name with configuration                                                  | Yes      | hacbs-signing-pipeline-config                                                         |
-| taskGitUrl      | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes      | https://github.com/konflux-ci/release-service-catalog.git                             |
-| taskGitRevision | The revision in the taskGitUrl repo to be used                                        | No       | -                                                                                     |
+| Name            | Description                                                                           | Optional | Default value                                                                                                                |
+|-----------------|---------------------------------------------------------------------------------------|----------|------------------------------------------------------------------------------------------------------------------------------|
+| pipeline_image  | An image with CLI tools needed for the signing                                        | Yes      | quay.io/redhat-isv/operator-pipelines-images:v1.15.0@sha256:4da314c5ddb6ac58f1d84ee7874c89768ce89f6b719f6778348992512088026d |
+| blob            | Blob that needs to be signed                                                          | No       | -                                                                                                                            |
+| requester       | Name of the user that requested the signing, for auditing purposes                    | No       | -                                                                                                                            |
+| config_map_name | A config map name with configuration                                                  | Yes      | hacbs-signing-pipeline-config                                                                                                |
+| taskGitUrl      | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes      | https://github.com/konflux-ci/release-service-catalog.git                                                                    |
+| taskGitRevision | The revision in the taskGitUrl repo to be used                                        | No       | -                                                                                                                            |

--- a/pipelines/internal/blob-signing-pipeline/blob-signing-pipeline.yaml
+++ b/pipelines/internal/blob-signing-pipeline/blob-signing-pipeline.yaml
@@ -12,7 +12,7 @@ spec:
   params:
     - name: pipeline_image
       description: An image with CLI tools needed for the signing
-      default: quay.io/redhat-isv/operator-pipelines-images:9ea90b42456fcdf66edf4b15c0c0487ba5fa3ee3
+      default: quay.io/redhat-isv/operator-pipelines-images:v1.15.0@sha256:4da314c5ddb6ac58f1d84ee7874c89768ce89f6b719f6778348992512088026d
       type: string
     - name: blob
       description: Blob that needs to be signed

--- a/tasks/managed/sign-base64-blob/sign-base64-blob.yaml
+++ b/tasks/managed/sign-base64-blob/sign-base64-blob.yaml
@@ -161,7 +161,7 @@ spec:
             exit 1
         fi
 
-        default_pipeline_image="quay.io/redhat-isv/operator-pipelines-images:9ea90b42456fcdf66edf4b15c0c0487ba5fa3ee3"
+        default_pipeline_image="quay.io/redhat-isv/operator-pipelines-images:v1.15.0@sha256:4da314c5ddb6ac58f1d84ee7874c89768ce89f6b719f6778348992512088026d"
         pipeline_image=$(jq -r --arg default_pipeline_image ${default_pipeline_image} \
             '.sign.pipelineImage // $default_pipeline_image' "${DATA_FILE}")
         config_map_name=$(jq -r '.sign.configMapName // "signing-config-map"' "${DATA_FILE}")

--- a/tasks/managed/sign-base64-blob/tests/test-sign-base64-blob.yaml
+++ b/tasks/managed/sign-base64-blob/tests/test-sign-base64-blob.yaml
@@ -169,8 +169,9 @@ spec:
                 exit 1
               fi
 
-              if [ "$(jq -r '.pipeline_image' <<< "${params}")" != \
-                 "quay.io/redhat-isv/operator-pipelines-images:9ea90b42456fcdf66edf4b15c0c0487ba5fa3ee3" ]
+              expected_pipeline_image="quay.io/redhat-isv/operator-pipelines-images:v1.15.0"
+              expected_pipeline_image="${expected_pipeline_image}@sha256:4da314c5ddb6ac58f1d84ee7874c89768ce89f6b719f6778348992512088026d"
+              if [ "$(jq -r '.pipeline_image' <<< "${params}")" != "${expected_pipeline_image}" ]
               then
                 echo "pipeline_image does not match"
                 exit 1


### PR DESCRIPTION
The operator-pipelines-images default was pinned to a commit-SHA tag that expired and was garbage-collected from Quay, causing ErrImagePull failures in request-signature. Pin to the v1.15.0 version tag instead, which does not expire.

Assisted-by: Cursor AI

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
