### PR TITLE
feat(CALUNGA-396): add logic for updates to npm dependency closure

### DIFF
--- a/pipelines/managed/calunga-push-npm-to-pulp/README.md
+++ b/pipelines/managed/calunga-push-npm-to-pulp/README.md
@@ -1,6 +1,6 @@
 # calunga-push-npm-to-pulp pipeline
 
-Release Components in a Snapshot to a pulp-backed npm registry. Each image in a Component is expected to be an OCI artifact containing npm .tgz packages (and optional *.tl-compliance.json sidecars) under the artifact root. First cut: no Atlas upload and no package signing (signing deferred). Compliance on Pulp is labels-only (tl.compliance_level from OCI sidecars); PULP_FILE_REPOSITORY is intentionally not passed so adjacent compliance JSON file uploads stay disabled until a file repo is provisioned.
+Release Components in a Snapshot to a pulp-backed npm registry. Each image in a Component is expected to be an OCI artifact containing npm .tgz packages (and optional *.tl-compliance.json sidecars) under the artifact root. First cut: no Atlas upload and no package signing (signing deferred). Compliance on Pulp is labels-only (tl.compliance_level from OCI sidecars); PULP_FILE_REPOSITORY is intentionally not passed so adjacent compliance JSON file uploads stay disabled until a file repo is provisioned. After Pulp upload, upload-npm-closure publishes per-package compliance OCI and the npm-closure-index on calunga-npm-registry-main (Quay refs hardcoded in the task).
 
 ## Parameters
 

--- a/pipelines/managed/calunga-push-npm-to-pulp/calunga-push-npm-to-pulp.yaml
+++ b/pipelines/managed/calunga-push-npm-to-pulp/calunga-push-npm-to-pulp.yaml
@@ -12,6 +12,9 @@ spec:
     Compliance on Pulp is labels-only (tl.compliance_level from OCI sidecars);
     PULP_FILE_REPOSITORY is intentionally not passed so adjacent compliance
     JSON file uploads stay disabled until a file repo is provisioned.
+    After Pulp upload, upload-npm-closure publishes per-package compliance OCI
+    and the npm-closure-index on calunga-npm-registry-main (Quay refs hardcoded
+    in the task).
   params:
     - name: release
       type: string
@@ -349,6 +352,46 @@ spec:
         - extract-npm-artifacts
         - collect-task-params
 
+    - name: push-npm-closure
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            value: $(params.taskGitUrl)
+          - name: revision
+            value: $(params.taskGitRevision)
+          - name: pathInRepo
+            value: tasks/managed/upload-npm-closure/upload-npm-closure.yaml
+      params:
+        - name: PULP_BASE_URL
+          value: $(tasks.collect-task-params.results.extractedValues[0])
+        - name: PULP_DOMAIN
+          value: $(tasks.collect-task-params.results.extractedValues[1])
+        - name: PULP_API_ROOT
+          value: $(tasks.collect-task-params.results.extractedValues[2])
+        - name: PULP_REPOSITORY
+          value: $(tasks.collect-task-params.results.extractedValues[3])
+        - name: SERVICE_ACCOUNT_SECRET_NAME
+          value: $(tasks.collect-task-params.results.extractedValues[4])
+        - name: sourceDataArtifact
+          value: "$(tasks.push-npm-pulp.results.sourceDataArtifact)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: taskGitUrl
+          value: $(params.taskGitUrl)
+        - name: taskGitRevision
+          value: $(params.taskGitRevision)
+        - name: ociStorage
+          value: $(tasks.config.results.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: ociArtifactExpiresAfter
+          value: $(params.ociArtifactExpiresAfter)
+      runAfter:
+        - push-npm-pulp
+
     - name: create-advisory
       taskRef:
         resolver: "git"
@@ -371,7 +414,7 @@ spec:
         - name: pipelineRunUid
           value: $(context.pipelineRun.uid)
         - name: sourceDataArtifact
-          value: "$(tasks.push-npm-pulp.results.sourceDataArtifact)"
+          value: "$(tasks.push-npm-closure.results.sourceDataArtifact)"
         - name: ociStorage
           value: $(tasks.config.results.ociStorage)
         - name: dataDir
@@ -387,7 +430,7 @@ spec:
         - name: ociArtifactExpiresAfter
           value: $(params.ociArtifactExpiresAfter)
       runAfter:
-        - push-npm-pulp
+        - push-npm-closure
 
   finally:
     - name: cleanup-internal-requests

--- a/tasks/managed/upload-npm-closure/README.md
+++ b/tasks/managed/upload-npm-closure/README.md
@@ -1,0 +1,28 @@
+# upload-npm-closure
+
+Publish TL npm closure metadata after Pulp upload: for each assess
+*.tl-compliance.json sidecar under FILES_DIR, push per-package compliance
+OCI and update the global closure index on Quay (calunga-npm-registry-main).
+Quay refs are fixed for calunga-tenant; COMPLIANCE_IMAGE_PREFIX and
+CLOSURE_INDEX_IMAGE are set in stepTemplate env. Requires Pulp
+credentials (same secret as upload-npm-pulp). Business logic runs as a
+single plumbing-utils command (npm-release-closure-update).
+
+## Parameters
+
+| Name                        | Description                                                                                           | Optional | Default value                |
+|-----------------------------|-------------------------------------------------------------------------------------------------------|----------|------------------------------|
+| SERVICE_ACCOUNT_SECRET_NAME | Secret with Pulp username/password keys (same as upload-npm-pulp)                                     | Yes      | rhtl-pulp-credentials-secret |
+| PULP_BASE_URL               | The base URL of the Pulp server                                                                       | No       | -                            |
+| PULP_API_ROOT               | The API root path of the Pulp server                                                                  | Yes      | /api/                        |
+| PULP_DOMAIN                 | The domain to use for Pulp operations                                                                 | No       | -                            |
+| PULP_REPOSITORY             | The Pulp npm repository (for content href resolution)                                                 | No       | -                            |
+| sourceDataArtifact          | Trusted Artifact containing extracted npm packages and sidecars                                       | No       | -                            |
+| dataDir                     | The location where data will be stored                                                                | Yes      | /var/workdir/content         |
+| filesDir                    | The relative path within dataDir where package files are located                                      | Yes      | files                        |
+| ociArtifactExpiresAfter     | Expiration date for the trusted artifacts created                                                     | Yes      | 1d                           |
+| orasOptions                 | oras options to pass to Trusted Artifacts calls                                                       | Yes      | ""                           |
+| trustedArtifactsDebug       | Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable                | Yes      | ""                           |
+| taskGitUrl                  | The url to the git repo where the release-service-catalog tasks and stepactions to be used are stored | No       | -                            |
+| taskGitRevision             | The revision in the taskGitUrl repo to be used                                                        | No       | -                            |
+| ociStorage                  | The OCI repository where the Trusted Artifacts are stored                                             | No       | -                            |

--- a/tasks/managed/upload-npm-closure/tests/mocks.sh
+++ b/tasks/managed/upload-npm-closure/tests/mocks.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Registry mocks prepended before npm-release-closure-update.
+# export -f is required: npm-release-closure-update runs as a bash subprocess.
+
+select-oci-auth() {
+  echo "Mock select-oci-auth called with: $*" >&2
+  echo '{"auths":{}}'
+}
+
+update-npm-closure() {
+  echo "Mock update-npm-closure $*" >> "${FILES_DIR}/.closure-call-log"
+}
+
+export -f select-oci-auth update-npm-closure

--- a/tasks/managed/upload-npm-closure/tests/pre-apply-task-hook.sh
+++ b/tasks/managed/upload-npm-closure/tests/pre-apply-task-hook.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SECRET_NAME="upload-npm-closure-test-credentials"
+kubectl create secret generic "${SECRET_NAME}" \
+  --from-literal=username=test-user \
+  --from-literal=password=test-password \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+TASK_PATH="${1}"
+SCRIPT_DIR="$(dirname -- "$(realpath -- "${BASH_SOURCE[0]}")")"
+MOCKS="${SCRIPT_DIR}/mocks.sh"
+
+wrapped="$(mktemp)"
+trap 'rm -f "${wrapped}"' EXIT
+
+{
+  echo '#!/usr/bin/env bash'
+  echo 'set -euo pipefail'
+  sed -e '1{/^#!/d;}' -e '/^set -euo pipefail$/d' "${MOCKS}"
+  echo
+  echo 'npm-release-closure-update'
+} > "${wrapped}"
+
+yq -i '
+  (.spec.steps[] | select(.name == "closure-update")) |=
+    (del(.command) | .script = load_str("'"${wrapped}"'"))
+' "${TASK_PATH}"

--- a/tasks/managed/upload-npm-closure/tests/test-upload-npm-closure.yaml
+++ b/tasks/managed/upload-npm-closure/tests/test-upload-npm-closure.yaml
@@ -1,0 +1,152 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-upload-npm-closure
+spec:
+  description: |
+    Sunny-day path for upload-npm-closure: two sidecars invoke update-npm-closure twice
+  params:
+    - name: ociStorage
+      type: string
+    - name: ociArtifactExpiresAfter
+      type: string
+      default: "1d"
+    - name: orasOptions
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      type: string
+      default: ""
+    - name: dataDir
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils@sha256:2f9e6863e82bbc9ddce5a290f3fd0e87657c475e3de8a832b2ef7f8d0671e7d3
+            script: |
+              #!/usr/bin/env bash
+              set -euxo pipefail
+
+              FILES="$(params.dataDir)/files/sha256_abc123"
+              mkdir -p "${FILES}"
+              jq -nc '{schema_version:3,name:"lodash",version:"4.17.21",compliance_level:"L3"}' \
+                > "${FILES}/lodash-4.17.21.tl-compliance.json"
+              jq -nc '{schema_version:3,name:"ms",version:"2.1.3",compliance_level:"L3"}' \
+                > "${FILES}/ms-2.1.3.tl-compliance.json"
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: upload-npm-closure
+      params:
+        - name: SERVICE_ACCOUNT_SECRET_NAME
+          value: upload-npm-closure-test-credentials
+        - name: PULP_BASE_URL
+          value: https://test.packages.redhat.com
+        - name: PULP_API_ROOT
+          value: /api
+        - name: PULP_DOMAIN
+          value: test-domain
+        - name: PULP_REPOSITORY
+          value: npm-registry
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: filesDir
+          value: files
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+        - name: ociStorage
+          value: $(params.ociStorage)
+      runAfter:
+        - setup
+    - name: check-result
+      params:
+        - name: sourceDataArtifact
+          value: "$(tasks.run-task.results.sourceDataArtifact)"
+        - name: dataDir
+          value: $(params.dataDir)
+      taskSpec:
+        params:
+          - name: sourceDataArtifact
+            type: string
+          - name: dataDir
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: use-trusted-artifact
+            ref:
+              name: use-trusted-artifact
+            params:
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(params.sourceDataArtifact)
+          - name: check-result
+            image: quay.io/konflux-ci/release-service-utils@sha256:2f9e6863e82bbc9ddce5a290f3fd0e87657c475e3de8a832b2ef7f8d0671e7d3
+            script: |
+              #!/usr/bin/env bash
+              set -euxo pipefail
+
+              LOG="$(params.dataDir)/files/.closure-call-log"
+              if [[ ! -f "${LOG}" ]]; then
+                echo "ERROR: missing closure call log at ${LOG}" >&2
+                exit 1
+              fi
+              COUNT="$(grep -c 'Mock update-npm-closure' "${LOG}" || true)"
+              if [[ "${COUNT}" -ne 2 ]]; then
+                echo "ERROR: expected 2 update-npm-closure calls, got ${COUNT}" >&2
+                cat "${LOG}" >&2
+                exit 1
+              fi
+              echo "Closure update loop checks passed"
+      runAfter:
+        - run-task

--- a/tasks/managed/upload-npm-closure/upload-npm-closure.yaml
+++ b/tasks/managed/upload-npm-closure/upload-npm-closure.yaml
@@ -2,36 +2,45 @@
 apiVersion: tekton.dev/v1
 kind: Task
 metadata:
-  name: extract-npm-artifacts
+  name: upload-npm-closure
 spec:
   description: |
-    Extract npm packages from OCI snapshot artifacts for Pulp upload.
-    Pulls each snapshot component image with oras into a digest-namespaced
-    directory, populates releaseNotes.content.artifacts from embedded SPDX
-    pkg:npm PURLs, and fetches Tekton Chains SLSA provenance (hard-fails if
-    missing, unverifiable, or not trusted). Provenance must match the image
-    digest and come from Konflux Chains with pipelineRef.name promote-npm or
-    build-npm and an invocationId in a trusted tenant namespace (default
-    calunga-tenant). Business logic runs as a single plumbing-utils command
-    (npm-release-extract); requires at least one .tgz after extract
+    Publish TL npm closure metadata after Pulp upload: for each assess
+    *.tl-compliance.json sidecar under FILES_DIR, push per-package compliance
+    OCI and update the global closure index on Quay (calunga-npm-registry-main).
+    Quay refs are fixed for calunga-tenant; COMPLIANCE_IMAGE_PREFIX and
+    CLOSURE_INDEX_IMAGE are set in stepTemplate env. Requires Pulp
+    credentials (same secret as upload-npm-pulp). Business logic runs as a
+    single plumbing-utils command (npm-release-closure-update).
   params:
-    - name: SNAPSHOT_PATH
+    - name: SERVICE_ACCOUNT_SECRET_NAME
       type: string
-      description: Path to the snapshot spec file containing image information
+      description: Secret with Pulp username/password keys (same as upload-npm-pulp)
+      default: rhtl-pulp-credentials-secret
+    - name: PULP_BASE_URL
+      type: string
+      description: The base URL of the Pulp server
+    - name: PULP_API_ROOT
+      type: string
+      description: The API root path of the Pulp server
+      default: "/api/"
+    - name: PULP_DOMAIN
+      type: string
+      description: The domain to use for Pulp operations
+    - name: PULP_REPOSITORY
+      type: string
+      description: The Pulp npm repository (for content href resolution)
     - name: sourceDataArtifact
       type: string
-      description: Trusted Artifact to use to obtain the Snapshot
+      description: Trusted Artifact containing extracted npm packages and sidecars
     - name: dataDir
       type: string
       description: The location where data will be stored
       default: /var/workdir/content
     - name: filesDir
       type: string
-      description: The relative path within dataDir where files will be extracted
+      description: The relative path within dataDir where package files are located
       default: files
-    - name: ociStorage
-      type: string
-      description: The OCI repository where the Trusted Artifacts are stored
     - name: ociArtifactExpiresAfter
       type: string
       description: Expiration date for the trusted artifacts created
@@ -44,13 +53,6 @@ spec:
       description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable
       type: string
       default: ""
-    - name: trustedProvenanceNamespaces
-      type: string
-      description: >
-        Comma-separated Kubernetes namespaces allowed to produce accepted
-        Chains provenance. Matched against runDetails.metadata.invocationId
-        as "<namespace>/..."
-      default: "calunga-tenant"
     - name: taskGitUrl
       type: string
       description: >-
@@ -59,34 +61,41 @@ spec:
     - name: taskGitRevision
       type: string
       description: The revision in the taskGitUrl repo to be used
-    - name: dataPath
+    - name: ociStorage
       type: string
-      description: Path to data.json relative to dataDir
+      description: The OCI repository where the Trusted Artifacts are stored
   results:
-    - name: sourceDataArtifact
-      description: Produced trusted data artifact
+    - description: Produced trusted data artifact
+      name: sourceDataArtifact
       type: string
   volumes:
+    - name: service-account-secret
+      secret:
+        secretName: $(params.SERVICE_ACCOUNT_SECRET_NAME)
     - name: workdir
       emptyDir: {}
   stepTemplate:
     securityContext:
       runAsUser: 1001
     env:
-      - name: SNAPSHOT_PATH
-        value: $(params.SNAPSHOT_PATH)
-      - name: IMAGES_TXT
-        value: $(params.dataDir)/images.txt
+      - name: PULP_BASE_URL
+        value: $(params.PULP_BASE_URL)
+      - name: PULP_API_ROOT
+        value: $(params.PULP_API_ROOT)
+      - name: PULP_DOMAIN
+        value: $(params.PULP_DOMAIN)
+      - name: PULP_REPOSITORY
+        value: $(params.PULP_REPOSITORY)
       - name: FILES_DIR
         value: $(params.dataDir)/$(params.filesDir)
+      - name: COMPLIANCE_IMAGE_PREFIX
+        value: quay.io/redhat-user-workloads/calunga-tenant/calunga-npm-registry-main
+      - name: CLOSURE_INDEX_IMAGE
+        value: quay.io/redhat-user-workloads/calunga-tenant/calunga-npm-registry-main:npm-closure-index
+      - name: TL_NPM_REGISTRY_URL
+        value: https://packages.redhat.com/api/pulp-content/public-trusted-libraries/javascript
       - name: IMAGE_EXPIRES_AFTER
         value: $(params.ociArtifactExpiresAfter)
-      - name: TRUSTED_ARTIFACTS_EXTRACT_DIR
-        value: $(params.dataDir)
-      - name: DATA_FILE
-        value: $(params.dataDir)/$(params.dataPath)
-      - name: TRUSTED_PROVENANCE_NAMESPACES
-        value: $(params.trustedProvenanceNamespaces)
       - name: "ORAS_OPTIONS"
         value: "$(params.orasOptions)"
       - name: "DEBUG"
@@ -116,15 +125,19 @@ spec:
           value: $(params.dataDir)
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
-    - name: extract
+    - name: closure-update
       image: quay.io/redhat-user-workloads/calunga-tenant/plumbing-utils@sha256:6c037044d1d15c614b0eaf64e2cfd1c65d8bf7da9080bd23c3a2a5a5cabe13d9
+      volumeMounts:
+        - name: service-account-secret
+          mountPath: "/etc/service-account-secret"
+          readOnly: true
       computeResources:
         limits:
-          memory: 256Mi
+          memory: 512Mi
         requests:
-          memory: 256Mi
+          memory: 512Mi
           cpu: 100m
-      command: ["npm-release-extract"]
+      command: ["npm-release-closure-update"]
     - name: create-trusted-artifact
       computeResources:
         limits:

--- a/tasks/managed/upload-npm-pulp/upload-npm-pulp.yaml
+++ b/tasks/managed/upload-npm-pulp/upload-npm-pulp.yaml
@@ -130,7 +130,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: upload
-      image: quay.io/redhat-user-workloads/calunga-tenant/plumbing-utils@sha256:4d8a0c051956f5ea4afcb7bdb0382372c34e0f1fece761e2e2bb2b4c45a516a2
+      image: quay.io/redhat-user-workloads/calunga-tenant/plumbing-utils@sha256:6c037044d1d15c614b0eaf64e2cfd1c65d8bf7da9080bd23c3a2a5a5cabe13d9
       volumeMounts:
         - name: service-account-secret
           mountPath: "/etc/service-account-secret"


### PR DESCRIPTION
Assisted-By: cursor 3.15.6

## Describe your changes

Adding new task that will update the dependency closure compliance level for packages and their parents recursively. This task will be called afte the upload-npm-pulp task runs.

## Relevant Jira
https://redhat.atlassian.net/browse/CALUNGA-396

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [x] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
