### PR TITLE
fix: detect multi-arch builds from directory structure instead of arc…

### DIFF
--- a/tasks/managed/push-oot-kmods-to-azure/push-oot-kmods-to-azure.yaml
+++ b/tasks/managed/push-oot-kmods-to-azure/push-oot-kmods-to-azure.yaml
@@ -138,14 +138,13 @@ spec:
         ACCOUNT="$(params.azureStorageAccount)"
         CONTAINER="$(params.azureContainer)"
 
-        # Check if this is a multi-architecture build
-        if [ -f "$(params.dataDir)/arch_count.txt" ]; then
-            arch_count=$(cat "$(params.dataDir)/arch_count.txt")
-            echo "Processing $arch_count architecture(s) for Azure upload"
-        else
-            echo "No architecture information found, assuming single architecture"
-            arch_count=1
+        # Detect architecture count from directory structure
+        arch_count=$(find "${SIGNED_KMODS_FULL_PATH}" -mindepth 1 -maxdepth 1 -type d | wc -l)
+        if [ "$arch_count" -eq 0 ]; then
+            echo "ERROR: No architecture directories found in ${SIGNED_KMODS_FULL_PATH}"
+            exit 1
         fi
+        echo "Detected $arch_count architecture(s) from directory structure"
 
         echo "Logging into Azure..."
         az login --service-principal \

--- a/tasks/managed/push-oot-kmods-to-git/push-oot-kmods-to-git.yaml
+++ b/tasks/managed/push-oot-kmods-to-git/push-oot-kmods-to-git.yaml
@@ -134,14 +134,13 @@ spec:
         mkdir -p "${GIT_WORK_DIR}"
         cd "${GIT_WORK_DIR}"
 
-        # Check if this is a multi-architecture build
-        if [ -f "$(params.dataDir)/arch_count.txt" ]; then
-            arch_count=$(cat "$(params.dataDir)/arch_count.txt")
-            echo "Processing $arch_count architecture(s) for Git upload"
-        else
-            echo "No architecture information found, assuming single architecture"
-            arch_count=1
+        # Detect architecture count from directory structure
+        arch_count=$(find "${SIGNED_KMODS_PATH}" -mindepth 1 -maxdepth 1 -type d | wc -l)
+        if [ "$arch_count" -eq 0 ]; then
+            echo "ERROR: No architecture directories found in ${SIGNED_KMODS_PATH}"
+            exit 1
         fi
+        echo "Detected $arch_count architecture(s) from directory structure"
 
         export GIT_LFS_SKIP_SMUDGE=1
         set +x # disable logging of the token

--- a/tasks/managed/push-oot-kmods-to-s3/push-oot-kmods-to-s3.yaml
+++ b/tasks/managed/push-oot-kmods-to-s3/push-oot-kmods-to-s3.yaml
@@ -133,14 +133,13 @@ spec:
 
         SIGNED_KMODS_FULL_PATH="$(params.dataDir)/$(params.signedKmodsPath)"
 
-        # Check if this is a multi-architecture build
-        if [ -f "$(params.dataDir)/arch_count.txt" ]; then
-            arch_count=$(cat "$(params.dataDir)/arch_count.txt")
-            echo "Processing $arch_count architecture(s) for S3 upload"
-        else
-            echo "No architecture information found, assuming single architecture"
-            arch_count=1
+        # Detect architecture count from directory structure
+        arch_count=$(find "${SIGNED_KMODS_FULL_PATH}" -mindepth 1 -maxdepth 1 -type d | wc -l)
+        if [ "$arch_count" -eq 0 ]; then
+            echo "ERROR: No architecture directories found in ${SIGNED_KMODS_FULL_PATH}"
+            exit 1
         fi
+        echo "Detected $arch_count architecture(s) from directory structure"
 
         # Function to upload artifacts for a specific architecture
         upload_arch_artifacts() {

--- a/tasks/managed/sign-oot-kmods/sign-oot-kmods.yaml
+++ b/tasks/managed/sign-oot-kmods/sign-oot-kmods.yaml
@@ -375,11 +375,12 @@ spec:
                             # Generate checksums for this architecture
                             echo "Generating checksums for $arch_name .ko files..."
                             cd "$arch_dir"
-                            if ls ./*.ko >/dev/null 2>&1; then
-                                sha256sum ./*.ko > "signed_kmods_checksums_${arch_name}.txt"
-                                echo "Generated checksums for $arch_name:"
-                                cat "signed_kmods_checksums_${arch_name}.txt"
+                            sigkmod_file="signed_kmods_checksums_${arch_name}.txt"
+                            find . -name "*.ko" -type f -exec sha256sum {} \; > "$sigkmod_file"
+                            if [ "$(wc -l < "$sigkmod_file")" -ne 0 ]; then
+                                echo "Generated checksums for $arch_name ($(wc -l < "$sigkmod_file") files)"
                             fi
+                            cd - > /dev/null
                             echo "Completed signing for $arch_name"
                         fi
                     fi


### PR DESCRIPTION

The refactor in https://github.com/konflux-ci/release-service-catalog/pull/2426 moved arch_count.txt creation from a dedicated detect-architectures bash step into the Python extract_oot_kmods module. While the file is still written correctly, it no longer survives the trusted artifact chain through sign-oot-kmods and prepare-and-finalize-artifacts, causing downstream push tasks (push-to-s3, push-to-git, push-to-azure) to fall back to single-arch mode and only upload the first architecture directory (amd64), silently dropping arm64.

Replace the arch_count.txt file check with a directory count of the actual architecture subdirectories under signed-kmods/. This is resilient to trusted artifact data loss since the directories are always present after extracting signed-kmods.tar.gz.

Also fix sign-oot-kmods checksum generation to use recursive find instead of root-level glob, which missed .ko files in subdirectories like build/drivers/net/ethernet/mellanox/mlx5/core/mlx5_core.ko.
`Assisted-By: Claude`
