### PR TITLE
refactor(RELEASE-2696): make e2e kubeconfig optional

### DIFF
--- a/integration-tests/lib/test-functions.sh
+++ b/integration-tests/lib/test-functions.sh
@@ -197,10 +197,12 @@ cleanup_resources() {
     if [ -n "$tmpDir" ] && [ -d "$tmpDir" ]; then
         echo "Deleting test resources..." | tee -a "${cleanup_log_file}"
         if [ -f "$tmpDir/tenant-resources.yaml" ]; then
-            kubectl delete -f "$tmpDir/tenant-resources.yaml" >> "${cleanup_log_file}" 2>&1
+            kubectl delete -f "$tmpDir/tenant-resources.yaml" -n "${tenant_namespace}" \
+              >> "${cleanup_log_file}" 2>&1
         fi
         if [ -f "$tmpDir/managed-resources.yaml" ]; then
-            kubectl delete -f "$tmpDir/managed-resources.yaml" >> "${cleanup_log_file}" 2>&1
+            kubectl delete -f "$tmpDir/managed-resources.yaml" -n "${managed_namespace}" \
+              >> "${cleanup_log_file}" 2>&1
         fi
         rm -rf "${tmpDir}"
     else
@@ -318,8 +320,13 @@ setup_namespaces() {
       log_error "Tenant namespace ${tenant_namespace} does not exist." 2
     fi
     set -eo pipefail # Re-enable exit on error
-    kubectl config set-context --current --namespace="$tenant_namespace"
-    echo "Namespaces setup complete. Current namespace set to ${tenant_namespace}."
+    # In-cluster auth has no kubeconfig current-context. Later kubectl calls pass -n.
+    if [ -n "${KUBECONFIG:-}" ]; then
+      kubectl config set-context --current --namespace="${tenant_namespace}"
+      echo "Namespaces setup complete. Current namespace set to ${tenant_namespace}."
+    else
+      echo "Namespaces setup complete. No KUBECONFIG; kubectl will use -n flags."
+    fi
 }
 
 # Function to resolve symlinks in a directory for kustomize compatibility
@@ -366,7 +373,7 @@ create_kubernetes_resources() {
     local max_retries=5
     local attempt
     for attempt in $(seq 1 "${max_retries}"); do
-        if kubectl create -f "$tmpDir/tenant-resources.yaml"; then
+        if kubectl create -f "$tmpDir/tenant-resources.yaml" -n "${tenant_namespace}"; then
             break
         fi
         if [ "${attempt}" -eq "${max_retries}" ]; then
@@ -379,7 +386,7 @@ create_kubernetes_resources() {
     echo "Building and applying managed resources..."
     kustomize build "$tmpDir/managed" | envsubst > "$tmpDir/managed-resources.yaml"
     for attempt in $(seq 1 "${max_retries}"); do
-        if kubectl apply -f "$tmpDir/managed-resources.yaml"; then
+        if kubectl apply -f "$tmpDir/managed-resources.yaml" -n "${managed_namespace}"; then
             break
         fi
         if [ "${attempt}" -eq "${max_retries}" ]; then

--- a/integration-tests/pipelines/e2e-tests-staging-pipeline.yaml
+++ b/integration-tests/pipelines/e2e-tests-staging-pipeline.yaml
@@ -26,6 +26,9 @@ spec:
     - name: KUBECONFIG_SECRET_NAME
       default: 'kubeconfig-secret'
       type: string
+      description: |
+        Secret with a kubeconfig key. Optional: if the secret is missing, kubectl uses
+        in-cluster configuration.
     - name: PIPELINE_TEST_SUITE_VARS
       default: '{}'
       type: string
@@ -117,6 +120,7 @@ spec:
                   secretKeyRef:
                     name: $(params.KUBECONFIG_SECRET_NAME)
                     key: kubeconfig
+                    optional: true
               - name: PR_NUMBER
                 valueFrom:
                   fieldRef:
@@ -202,13 +206,17 @@ spec:
               export VAULT_PASSWORD_FILE
               set +x
               echo "${VAULT_PASSWORD:?}" > "${VAULT_PASSWORD_FILE}"
+              # KUBECONFIG is optional. When unset, kubectl uses in-cluster config.
+              if [ -n "${KUBECONFIG:-}" ]; then
+                KUBECONFIG_FILE="$(mktemp)"
+                echo "${KUBECONFIG}" > "${KUBECONFIG_FILE}"
+                KUBECONFIG="${KUBECONFIG_FILE}"
+                export KUBECONFIG
+              else
+                # An empty KUBECONFIG value would block in-cluster auth.
+                unset KUBECONFIG
+              fi
               set -x
-              KUBECONFIG_FILE=$(mktemp)
-              set +x
-              echo "${KUBECONFIG:?}" > "${KUBECONFIG_FILE}"
-              set -x
-              KUBECONFIG="${KUBECONFIG_FILE}"
-              export KUBECONFIG
 
               RELEASE_CATALOG_GIT_URL="$(params.PR_GIT_URL)"
               RELEASE_CATALOG_GIT_REVISION="$(params.PR_GIT_REVISION)"
@@ -290,6 +298,7 @@ spec:
                   secretKeyRef:
                     name: $(params.KUBECONFIG_SECRET_NAME)
                     key: kubeconfig
+                    optional: true
               - name: uuid
                 value: $(context.pipelineRun.uid)
               - name: VAULT_PASSWORD
@@ -346,13 +355,17 @@ spec:
               export VAULT_PASSWORD_FILE
               set +x
               echo "${VAULT_PASSWORD:?}" > "${VAULT_PASSWORD_FILE}"
+              # KUBECONFIG is optional. When unset, kubectl uses in-cluster config.
+              if [ -n "${KUBECONFIG:-}" ]; then
+                KUBECONFIG_FILE="$(mktemp)"
+                echo "${KUBECONFIG}" > "${KUBECONFIG_FILE}"
+                KUBECONFIG="${KUBECONFIG_FILE}"
+                export KUBECONFIG
+              else
+                # An empty KUBECONFIG value would block in-cluster auth.
+                unset KUBECONFIG
+              fi
               set -x
-              KUBECONFIG_FILE=$(mktemp)
-              set +x
-              echo "${KUBECONFIG:?}" > "${KUBECONFIG_FILE}"
-              set -x
-              KUBECONFIG="${KUBECONFIG_FILE}"
-              export KUBECONFIG
 
               # decrypt the secrets since they are part of the resources to be deleted
               #
@@ -374,8 +387,12 @@ spec:
               # they might be already deleted from the cleanup trap
               #
               echo "Deleting resources..."
-              kubectl delete -f "$tmpDir/tenant-resources.yaml" --ignore-not-found
-              kubectl delete -f "$tmpDir/managed-resources.yaml" --ignore-not-found
+              # shellcheck disable=SC2154 # tenant_namespace and managed_namespace come from test.env
+              kubectl delete -f "$tmpDir/tenant-resources.yaml" -n "${tenant_namespace}" \
+                --ignore-not-found
+              # shellcheck disable=SC2154
+              kubectl delete -f "$tmpDir/managed-resources.yaml" -n "${managed_namespace}" \
+                --ignore-not-found
 
               # Delete Release CRs created by this test run using uuid label
               if [ -n "$uuid" ] && [ -n "$tenant_namespace" ]; then

--- a/integration-tests/scripts/get-advisory-content.sh
+++ b/integration-tests/scripts/get-advisory-content.sh
@@ -66,7 +66,7 @@ validate_params() {
 
 # Function to set up environment variables and configurations
 setup_env() {
-  if [ -n "$KUBECONFIG" ]; then
+  if [ -n "${KUBECONFIG:-}" ]; then
     echo "Using provided KUBECONFIG"
   fi
 
@@ -85,8 +85,6 @@ setup_env() {
     echo "Defaulting to RELEASE_CATALOG_GIT_REVISION: ${RELEASE_CATALOG_GIT_REVISION}"
   fi
   export RELEASE_CATALOG_GIT_REVISION # Export to make it available
-
-  kubectl config set-context --current --namespace="${managed_namespace}"
 }
 
 # Function to create and apply PipelineRun YAML
@@ -104,6 +102,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   generateName: request-advisory-oci-artifact-
+  namespace: ${managed_namespace}
   labels:
     ${pipelinerun_label_param}: ${uuid_param}
 spec:
@@ -127,7 +126,7 @@ spec:
         value: pipelines/internal/request-advisory-oci-artifact/request-advisory-oci-artifact.yaml
 EOF
 
-  kubectl create -f "${pipelinerunYaml}" > /dev/null 2> /dev/null
+  kubectl create -f "${pipelinerunYaml}" -n "${managed_namespace}" > /dev/null 2> /dev/null
   rm "${pipelinerunYaml}" # Clean up temp file
 
   # Return the PipelineRun name


### PR DESCRIPTION
This commit makes the kubeconfig secret in the
e2e-tests-staging-pipeline optional. The current setup is to authenticate to the stage cluster from the prod cluster using the kubeconfig secret. We are migrating to orchestrating it all from the stage cluster and not using prod at all, so this makes the kubeconfig secret optional. Once the migration is complete, we will likely end up removing the kubeconfig secret from the e2e-tests-staging-pipeline entirely.

Assisted-By: Cursor

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
