### PR TITLE
RELEASE-2788: Make create-github-release binary asset globs optional

### DIFF
--- a/tasks/managed/create-github-release/README.md
+++ b/tasks/managed/create-github-release/README.md
@@ -5,6 +5,9 @@ Tekton task that creates a release in GitHub.com via the API.
 It extracts binary files from the container image and uploads them along with
 SHA256SUMS and signature files (from the TA chain) to the GitHub release.
 
+Binary uploads accept any combination of *.zip, *.tar.gz, and *.json from the
+image. SHA256SUMS and .sig files from the trusted-artifact chain are required.
+
 ## Parameters
 
 | Name                    | Description                                                                                                                | Optional | Default value        |

--- a/tasks/managed/create-github-release/create-github-release.yaml
+++ b/tasks/managed/create-github-release/create-github-release.yaml
@@ -12,6 +12,9 @@ spec:
 
     It extracts binary files from the container image and uploads them along with
     SHA256SUMS and signature files (from the TA chain) to the GitHub release.
+
+    Binary uploads accept any combination of *.zip, *.tar.gz, and *.json from the
+    image. SHA256SUMS and .sig files from the trusted-artifact chain are required.
   params:
     - name: repository
       type: string
@@ -202,11 +205,30 @@ spec:
 
           cd "$CONTENT_DIR"
           set -o pipefail
+
+          # Binary asset types vary by product (e.g. Terraform ships *.json;
+          # ROSA CLI ships *.zip and *.tar.gz). Treat those as optional.
+          # SHA256SUMS and .sig from the TA chain remain required.
+          shopt -s nullglob
+          binary_assets=(
+            "$BINARIES_TMP"/*.zip
+            "$BINARIES_TMP"/*.tar.gz
+            "$BINARIES_TMP"/*.json
+          )
+          shopt -u nullglob
+
+          if [ ${#binary_assets[@]} -eq 0 ]; then
+            echo "Error: no binary assets (*.zip, *.tar.gz, or *.json) found to upload."
+            exit 1
+          fi
+
           shopt -s failglob
+          required_assets=(./*SHA256SUMS ./*.sig)
+          shopt -u failglob
 
           gh release create "v${RELEASE_VERSION}" \
-            "$BINARIES_TMP"/*.zip "$BINARIES_TMP"/*.json \
-            ./*SHA256SUMS ./*.sig \
+            "${binary_assets[@]}" \
+            "${required_assets[@]}" \
             --repo "$REPOSITORY" --title "Release $RELEASE_VERSION" | tee "$(results.url.path)"
 
           rm -rf "$BINARIES_TMP"


### PR DESCRIPTION
## Summary
- `create-github-release` used `failglob` on `$BINARIES_TMP/*.json`, so products that do not ship a JSON artifact (e.g. ROSA CLI) failed with `no match: *.json`.
- Collect optional binaries (`*.zip`, `*.tar.gz`, `*.json`) with `nullglob`, and keep SHA256SUMS / `.sig` required.
- Also upload `*.tar.gz` when present (ROSA CLI ships both zip and tar.gz).

Jira: https://redhat.atlassian.net/browse/RELEASE-2788  
Related support: https://redhat.atlassian.net/browse/KFLUXSPRT-8822

## Test plan
- [ ] Existing `create-github-release` unit tests pass (zip + json fixtures)
- [ ] ROSA CLI release on development catalog gets past `create-github-release` without a dummy JSON
- [ ] Terraform-style release that ships `*.json` still uploads those assets


Made with [Cursor](https://cursor.com)