### PR TITLE
fix(KFLUXSPRT-8832): fix corrupted docker config in disk-images push

### DIFF
--- a/tasks/internal/pulp-push-disk-images/pulp-push-disk-images.yaml
+++ b/tasks/internal/pulp-push-disk-images/pulp-push-disk-images.yaml
@@ -206,8 +206,20 @@ spec:
         echo "$PULP_KEY" > "$PULP_KEY_FILE"
         echo "$UDC_CERT" > "$UDCACHE_CERT"
         echo "$UDC_KEY" > "$UDCACHE_KEY"
-        # Quotes are added to the secret so it applies in k8s nicely. But now we have to remove them
-        echo "$DOCKER_CONFIG_JSON" | sed -r 's/(^|\})[^{}]+(\{|$)/\1\2/g' > ~/.docker/config.json
+        # Quotes are added to the secret so it applies in k8s nicely, so strip a single layer of
+        # wrapping quotes (single or double) before writing it out. The previous brace-counting sed
+        # here corrupted the JSON whenever the pull secret contained more than one registry entry: it
+        # would eat the comma and key between adjacent "}...{" pairs (e.g. between two "auths" entries),
+        # producing invalid JSON that only surfaced later as a cryptic parse error from select-oci-auth.
+        DOCKER_CONFIG_JSON="${DOCKER_CONFIG_JSON%\"}"
+        DOCKER_CONFIG_JSON="${DOCKER_CONFIG_JSON#\"}"
+        DOCKER_CONFIG_JSON="${DOCKER_CONFIG_JSON%\'}"
+        DOCKER_CONFIG_JSON="${DOCKER_CONFIG_JSON#\'}"
+        if ! jq -e -s 'length == 1 and (.[0] | type) == "object"' <<< "${DOCKER_CONFIG_JSON}" > /dev/null 2>&1 ; then
+            echo "ERROR: redhat-workloads-token .dockerconfigjson is not valid JSON after unwrapping quotes" >&2
+            exit 1
+        fi
+        echo "${DOCKER_CONFIG_JSON}" > ~/.docker/config.json
         set -x
 
         DISK_IMAGE_DIR="$(mktemp -d)"

--- a/tasks/internal/pulp-push-disk-images/tests/pre-apply-task-hook.sh
+++ b/tasks/internal/pulp-push-disk-images/tests/pre-apply-task-hook.sh
@@ -30,4 +30,4 @@ kubectl create secret generic pulp-task-cgw-secret --from-literal=username=cgwus
 # Create a dummy workloads secret (and delete it first if it exists)
 # The secret name here is hardcoded in the task
 kubectl delete secret redhat-workloads-token --ignore-not-found
-kubectl create secret generic redhat-workloads-token --from-literal=.dockerconfigjson={"auths":{"quay.io":{"auth":"abcdefg"}}}
+kubectl create secret generic redhat-workloads-token --from-literal='.dockerconfigjson={"auths":{"quay.io":{"auth":"abcdefg"}}}'


### PR DESCRIPTION
pulp-push-disk-images stripped the quotes wrapping the redhat-workloads-token dockerconfigjson secret using a brace-counting sed regex. That regex only tolerates a single registry entry: with two or more auths entries it eats the comma and key between adjacent "}...{" pairs, producing invalid JSON.

select-oci-auth then fails to parse ~/.docker/config.json, aborting the whole task (all components share one auth file) with a cryptic "did not find expected ',' or '}'" error deep in a parallel subprocess's stderr - hard to trace back to the real cause.

Confirmed against the actual redhat-workloads-token secret content in the prod cluster: it has 2 registry entries and the sed produces invalid JSON, while a plain single-quote-layer strip does not.

Replace the sed with a targeted strip of one wrapping quote char (single or double) from each end, followed by a jq validation that fails fast with a clear error if the result still isn't valid JSON.

Assisted-By: Cursor

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
