### PR TITLE
fix(RELEASE-2748): fail loudly on swallowed task errors

### DIFF
--- a/tasks/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
+++ b/tasks/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml
@@ -141,7 +141,7 @@ spec:
           cpu: 650m
       script: |
         #!/usr/bin/env bash
-        set -ex
+        set -exo pipefail
 
         TASK_LABEL="internal-services.appstudio.openshift.io/group-id"
         TASK_ID=$(context.taskRun.uid)
@@ -259,7 +259,8 @@ spec:
           --no-headers -o custom-columns=":metadata.name" \
           --sort-by=.metadata.creationTimestamp | tail -1)
         if [ -z "${NAME}" ]; then
-          echo "Warning: Unable to get InternalRequest name"
+          echo "ERROR: Unable to get InternalRequest name"
+          exit 1
         fi
 
         results=$(kubectl get internalrequest "${NAME}" -o=jsonpath='{.status.results}')

--- a/tasks/managed/rh-sign-image-cosign/rh-sign-image-cosign.yaml
+++ b/tasks/managed/rh-sign-image-cosign/rh-sign-image-cosign.yaml
@@ -149,7 +149,7 @@ spec:
           mountPath: "/etc/secrets"
       script: |
         #!/usr/bin/env bash
-        set -eu
+        set -euo pipefail
 
         AWS_DEFAULT_REGION="$(cat /etc/secrets/AWS_DEFAULT_REGION)"
         AWS_ACCESS_KEY_ID="$(cat /etc/secrets/AWS_ACCESS_KEY_ID)"
@@ -205,7 +205,9 @@ spec:
         }
         echopid(){
             pid=$(jobpid)
-            echo "${pid}: $*"
+            # Written to stderr so it never leaks into a caller's $(...) capture,
+            # e.g. run_cosign's stdout is captured as cosign's own JSON output.
+            echo "${pid}: $*" >&2
         }
         run_cosign () { # Expected arguments are [digest_reference, tag_reference]
             attempt=0
@@ -240,10 +242,16 @@ spec:
               COSIGN_REKOR_ARGS+=("--insecure-ignore-tlog=true")
           fi
           verify_output=$(run_cosign verify "${COSIGN_REKOR_ARGS[@]}" --key "$PUBLIC_KEY_FILE" "$reference")
-          found_signatures=$(echo "$verify_output" | jq -j '['\
+          if [ -z "$verify_output" ]; then
+            verify_output="[]"
+          fi
+          if ! found_signatures=$(echo "$verify_output" | jq -j '['\
         '.[]|select(.critical.image."docker-manifest-digest"| contains("'"$digest"'"))'\
         '|select(.critical.identity."docker-reference" == "'"$identity"'")'\
-        ']|length')
+        ']|length'); then
+            echopid "ERROR: cosign verify output for ${reference} was not valid JSON: ${verify_output}"
+            exit 1
+          fi
           echo "$found_signatures"
         }
         function check_and_sign() {
@@ -260,7 +268,8 @@ spec:
           declare -a COSIGN_REKOR_ARGS=()
           found_signatures=$(check_existing_signatures "$identity" "$reference@$digest" "$digest")
           if [ -z "$found_signatures" ]; then
-            found_signatures=0
+            echopid "ERROR: empty signature count for ${identity} ${digest}"
+            exit 1
           fi
           echopid "FOUND SIGNATURES for ${identity} ${digest}: $found_signatures"
 
@@ -377,10 +386,11 @@ spec:
         import sys
         from itertools import zip_longest
         digest_groups = {}
-        # #
+        data = sys.stdin.read().strip()
+        if not data:
+          raise SystemExit(0)
         # Make groups based on reference + digest to avoid signing same digest in parallel
-        # #
-        for x in sys.stdin.read().strip().split(' '):
+        for x in data.split(' '):
           rest, internal_ref = x.split('#')
           rest, digest = rest.split('@')
           public_ref, tag = rest.split(':')

--- a/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-fail-invalid-verify-output.yaml
+++ b/tasks/managed/rh-sign-image-cosign/tests/test-rh-sign-image-cosign-fail-invalid-verify-output.yaml
@@ -1,0 +1,128 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-rh-sign-image-cosign-fail-invalid-verify-output
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Run rh-sign-image-cosign where "cosign verify" exits successfully but prints
+    output that isn't valid JSON, and verify the task fails loudly instead of
+    silently treating it as "no signatures found" and skipping signing.
+  params:
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: "1d"
+    - name: orasOptions
+      description: oras options to pass to Trusted Artifacts calls
+      type: string
+      default: "--insecure"
+    - name: trustedArtifactsDebug
+      description: Flag to enable debug logging in trusted artifacts. Set to a non-empty string to enable.
+      type: string
+      default: ""
+    - name: dataDir
+      description: The location where data will be stored
+      type: string
+  tasks:
+    - name: setup
+      taskSpec:
+        results:
+          - name: sourceDataArtifact
+            type: string
+        volumes:
+          - name: workdir
+            emptyDir: {}
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+            - name: "ORAS_OPTIONS"
+              value: "$(params.orasOptions)"
+            - name: "DEBUG"
+              value: "$(params.trustedArtifactsDebug)"
+        steps:
+          - name: setup-values
+            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/snapshot_spec.json" << EOF
+              {
+                "application": "myapp",
+                "components": [
+                  {
+                    "name": "comp0",
+                    "containerImage": "quay.io/redhat-user-workloads/test-product/test-image2@sha256:2222",
+                    "repositories": [
+                      {
+                        "url": "quay.io/redhat-pending/test-product----test-image2",
+                        "rh-registry-repo": "registry.stage.redhat.io/test-product/test-image2",
+                        "tags": ["t1"]
+                      }
+                    ]
+                  }
+                ]
+              }
+              EOF
+
+              # "cosign verify" exits 0 (success) but its output isn't valid JSON
+              for REF in \
+                "quay.io/redhat-pending/test-product----test-image2@sha256:2222" \
+                "registry.stage.redhat.io/test-product/test-image2@sha256:2222" \
+                "registry.access.stage.redhat.com/test-product/test-image2@sha256:2222"
+              do
+                echo "not valid json {" > "$(params.dataDir)/$(echo "${REF}" | tr '/' '-')"
+              done
+              echo "1" >> "$(params.dataDir)/mock_cosign_success_calls"
+
+              cat > "$(params.dataDir)/$(context.pipelineRun.uid)/signRegistryAccess.txt" << EOF
+              test-product/test-image2
+              EOF
+          - name: create-trusted-artifact
+            ref:
+              name: create-trusted-artifact
+            params:
+              - name: ociStorage
+                value: $(params.ociStorage)
+              - name: workDir
+                value: $(params.dataDir)
+              - name: sourceDataArtifact
+                value: $(results.sourceDataArtifact.path)
+    - name: run-task
+      taskRef:
+        name: rh-sign-image-cosign
+      params:
+        - name: snapshotPath
+          value: $(context.pipelineRun.uid)/snapshot_spec.json
+        - name: secretName
+          value: 'test-cosign-secret'
+        - name: signRegistryAccessPath
+          value: $(context.pipelineRun.uid)/signRegistryAccess.txt
+        - name: ociStorage
+          value: $(params.ociStorage)
+        - name: orasOptions
+          value: $(params.orasOptions)
+        - name: sourceDataArtifact
+          value: "$(tasks.setup.results.sourceDataArtifact)=$(params.dataDir)"
+        - name: dataDir
+          value: $(params.dataDir)
+        - name: trustedArtifactsDebug
+          value: $(params.trustedArtifactsDebug)
+        - name: taskGitUrl
+          value: "http://localhost"
+        - name: taskGitRevision
+          value: "main"
+      runAfter:
+        - setup

--- a/tasks/managed/run-file-updates/run-file-updates.yaml
+++ b/tasks/managed/run-file-updates/run-file-updates.yaml
@@ -140,9 +140,7 @@ spec:
           cpu: 650m
       script: |
         #!/bin/bash
-        #
-        #
-        set -ex
+        set -exo pipefail
 
         # Obtain componentGroup from snapshot
         componentGroup=$(jq -rc .componentGroup "$(params.dataDir)/$(params.snapshotPath)")
@@ -207,17 +205,24 @@ spec:
             -o jsonpath='{.items[0]}' --sort-by=.metadata.creationTimestamp )
 
           results=$(jq -r '.status.results' <<< "${IRjson}")
+          if [ -z "${results}" ] || [ "${results}" = "null" ]; then
+            echo "ERROR: InternalRequest returned empty results"
+            echo "${IRjson}"
+            exit 1
+          fi
           internalRequestPipelineRunName="$(jq -jr '.internalRequestPipelineRunName // ""' <<< "${results}")"
           internalRequestTaskRunName="$(jq -jr '.internalRequestTaskRunName // ""' <<< "${results}")"
 
           echo "** internalRequestPipelineRunName: ${internalRequestPipelineRunName}"
           echo "** internalRequestTaskRunName: ${internalRequestTaskRunName}"
 
-          if [ "$(jq -jr '.buildState' <<< "${results}")" == "Failed" ]; then
-            echo -en "  FileUpdates Error: "
-            jq -r '.jsonBuildInfo | fromjson | .error' <<< "${results}"
+          buildState="$(jq -jr '.buildState // empty' <<< "${results}")"
+          if [ "${buildState}" != "Success" ] && [ "${buildState}" != "Succeeded" ]; then
+            echo -en "  FileUpdates Error (buildState=${buildState}): "
+            jq -r '.jsonBuildInfo | fromjson | .error // empty' <<< "${results}" || true
             echo -e "  Diff (content might be truncated): "
-            jq -r '.jsonBuildInfo | fromjson | .str | tostring' <<< "${results}" | awk '{ print "\t"$0 }'
+            jq -r '.jsonBuildInfo | fromjson | .str | tostring' <<< "${results}" 2>/dev/null \
+              | awk '{ print "\t"$0 }' || true
             echo -e "=== Finished ===\n"
             exit 1
           else

--- a/tasks/managed/sign-image-cosign-keyless/sign-image-cosign-keyless.yaml
+++ b/tasks/managed/sign-image-cosign-keyless/sign-image-cosign-keyless.yaml
@@ -153,7 +153,7 @@ spec:
           readOnly: true
       script: |
         #!/usr/bin/env bash
-        set -eu
+        set -euo pipefail
 
         if [ -f "/mnt/trusted-ca/ca-bundle.crt" ]; then
             export SSL_CERT_FILE="/mnt/trusted-ca/ca-bundle.crt"
@@ -203,7 +203,9 @@ spec:
         }
         echopid(){
             pid=$(jobpid)
-            echo "${pid}: $*"
+            # Written to stderr so it never leaks into a caller's $(...) capture,
+            # e.g. run_cosign's stdout is captured as cosign's own JSON output.
+            echo "${pid}: $*" >&2
         }
         run_cosign () { # Expected arguments are [digest_reference, tag_reference]
             attempt=0
@@ -233,10 +235,16 @@ spec:
           COSIGN_REKOR_ARGS+=("--certificate-identity=${CERTIFICATE_IDENTITY}"
             "--certificate-oidc-issuer=$(params.keylessOIDCIssuer)")
           verify_output=$(run_cosign verify "${COSIGN_REKOR_ARGS[@]}" "$reference")
-          found_signatures=$(echo "$verify_output" | jq -j '['\
+          if [ -z "$verify_output" ]; then
+            verify_output="[]"
+          fi
+          if ! found_signatures=$(echo "$verify_output" | jq -j '['\
         '.[]|select(.critical.image."docker-manifest-digest"| contains("'"$digest"'"))'\
         '|select(.critical.identity."docker-reference" == "'"$identity"'")'\
-        ']|length')
+        ']|length'); then
+            echopid "ERROR: cosign verify output for ${reference} was not valid JSON: ${verify_output}"
+            exit 1
+          fi
           echo "$found_signatures"
         }
         function check_and_sign() {
@@ -253,7 +261,8 @@ spec:
           declare -a COSIGN_REKOR_ARGS=()
           found_signatures=$(check_existing_signatures "$identity" "$reference@$digest" "$digest")
           if [ -z "$found_signatures" ]; then
-            found_signatures=0
+            echopid "ERROR: empty signature count for ${identity} ${digest}"
+            exit 1
           fi
           echopid "FOUND SIGNATURES for ${identity} ${digest}: $found_signatures"
           COSIGN_REKOR_ARGS+=("-y" "--rekor-url=$REKOR_URL")


### PR DESCRIPTION
Cosign verify parse errors, InternalRequest tee pipelines, and empty IR results could report success when the work failed.

Assisted-by: Cursor AI

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
