### PR TITLE
test(RELEASE-2334): assert merge_request_url in rh-push-to-ext e2e

### DIFF
--- a/integration-tests/rh-push-to-external-registry-multi-component/resources/managed/rpa.yaml
+++ b/integration-tests/rh-push-to-external-registry-multi-component/resources/managed/rpa.yaml
@@ -24,6 +24,16 @@ spec:
         - name: ${component2_name}
           repositories:
             - url: quay.io/redhat-pending/rhtap----rh-advisories-component-2
+    fileUpdates:
+      - paths:
+          - path: data/teams/stonesoup/users/shebert.yml
+            replacements:
+              - key: .tag_on_cluster_updates
+                replacement: >-
+                  |^tag_on_cluster_updates:.*|tag_on_cluster_updates: {{ .components[0].containerImage }}|
+        repo: 'https://gitlab.cee.redhat.com/hacbs-release-tests/app-interface/'
+        upstream_repo: 'https://gitlab.cee.redhat.com/hacbs-release-tests/app-interface/'
+        ref: 'master'
   origin: ${tenant_namespace}
   pipeline:
     pipelineRef:

--- a/integration-tests/rh-push-to-external-registry-multi-component/test.sh
+++ b/integration-tests/rh-push-to-external-registry-multi-component/test.sh
@@ -62,6 +62,18 @@ verify_release_contents() {
     # Verify multi-component images using shared helper
     check_container_images
 
+    # Verify run-file-updates merge request URL (RELEASE-2334)
+    echo ""
+    echo "Checking merge request URL from run-file-updates..."
+    local merge_request_url
+    merge_request_url="$(jq -r '.status.artifacts.merge_requests[0]?.url // ""' <<< "${release_json}")"
+    if [ -n "${merge_request_url}" ] && [ "${merge_request_url}" != "unknown" ]; then
+        echo "✅️ Found merge request URL: ${merge_request_url}"
+    else
+        echo "🔴 merge_requests[0].url is empty, missing, or invalid (got: '${merge_request_url}')"
+        failures=$((failures+1))
+    fi
+
     # Additional verification: ensure distinct URLs and shasums for multi-component test
     echo ""
     echo "Verifying distinct URLs and shasums for each component..."

--- a/integration-tests/rh-push-to-external-registry/resources/managed/rpa.yaml
+++ b/integration-tests/rh-push-to-external-registry/resources/managed/rpa.yaml
@@ -21,6 +21,16 @@ spec:
         - name: ${component_name}
           repositories:
             - url: quay.io/redhat-pending/rhtap----rh-advisories-component
+    fileUpdates:
+      - paths:
+          - path: data/teams/stonesoup/users/shebert.yml
+            replacements:
+              - key: .tag_on_cluster_updates
+                replacement: >-
+                  |^tag_on_cluster_updates:.*|tag_on_cluster_updates: {{ .components[0].containerImage }}|
+        repo: 'https://gitlab.cee.redhat.com/hacbs-release-tests/app-interface/'
+        upstream_repo: 'https://gitlab.cee.redhat.com/hacbs-release-tests/app-interface/'
+        ref: 'master'
   origin: ${tenant_namespace}
   pipeline:
     pipelineRef:

--- a/integration-tests/rh-push-to-external-registry/test.sh
+++ b/integration-tests/rh-push-to-external-registry/test.sh
@@ -35,6 +35,18 @@ verify_release_contents() {
     # Verify container images using shared helper
     check_container_images
 
+    # Verify run-file-updates merge request URL (RELEASE-2334)
+    echo ""
+    echo "Checking merge request URL from run-file-updates..."
+    local merge_request_url
+    merge_request_url="$(jq -r '.status.artifacts.merge_requests[0]?.url // ""' <<< "${release_json}")"
+    if [ -n "${merge_request_url}" ] && [ "${merge_request_url}" != "unknown" ]; then
+        echo "✅️ Found merge request URL: ${merge_request_url}"
+    else
+        echo "🔴 merge_requests[0].url is empty, missing, or invalid (got: '${merge_request_url}')"
+        failures=$((failures+1))
+    fi
+
     echo "Checking Image IDs..."
     pyxisDataFile=$(find ${oci_artifact_dir} -name "pyxis.json")
     imageIds=$(jq -r '[.components[].pyxisImages[].imageId] | join(" ")' "${pyxisDataFile}")


### PR DESCRIPTION
## Describe your changes
- Add `fileUpdates` configuration to rh-push-to-external-registry and multi-component test RPAs
- Assert `status.artifacts.merge_requests[0].url` is non-empty in both e2e tests

## Relevant Jira
[RELEASE-2334](https://redhat.atlassian.net/browse/RELEASE-2334)

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [x] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`

Assisted-by: Claude

[RELEASE-2334]: https://redhat.atlassian.net/browse/RELEASE-2334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ