### PR TITLE
fix(KFLUXSPRT-8854): temp files to merge-json to avoid ARG_MAX

### DIFF
--- a/tasks/managed/apply-mapping/apply-mapping.yaml
+++ b/tasks/managed/apply-mapping/apply-mapping.yaml
@@ -157,7 +157,7 @@ spec:
         - name: caCertPath
           value: $(params.caCertPath)
     - name: apply-mapping
-      image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+      image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
       computeResources:
         limits:
           memory: 64Mi
@@ -517,7 +517,10 @@ spec:
         # $(...) subshells (via translate_tags), so bash associative array writes
         # would be lost on subshell exit. Files persist across subshell boundaries.
         _inc_cache_dir=$(mktemp -d)
-        trap 'rm -rf "${_inc_cache_dir}"' EXIT
+        CGW_DEFAULT_FILE=$(mktemp)
+        CGW_COMPONENT_FILE=$(mktemp)
+        printf '%s' "${defaultCGWSettings}" > "${CGW_DEFAULT_FILE}"
+        trap 'rm -rf "${_inc_cache_dir}"; rm -f "${CGW_DEFAULT_FILE}" "${CGW_COMPONENT_FILE}"' EXIT
 
         for ((i = 0; i < NUM_MAPPED_COMPONENTS; i++)) ; do
             # Clear the cache at the start of each component so that different
@@ -664,7 +667,8 @@ spec:
 
             # apply defaults for contentGateway
             componentCGWSettings=$(jq -c '.contentGateway // {}' <<< "$component")
-            updatedComponentCGWSettings=$(merge-json "$defaultCGWSettings" "$componentCGWSettings")
+            printf '%s' "${componentCGWSettings}" > "${CGW_COMPONENT_FILE}"
+            updatedComponentCGWSettings=$(merge-json "${CGW_DEFAULT_FILE}" "${CGW_COMPONENT_FILE}")
             componentCGWSettingsSize=$(jq '. | length' <<< "${updatedComponentCGWSettings}")
 
             if [ "${componentCGWSettingsSize}" -gt "0" ]; then

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-component-incrementer.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-component-incrementer.yaml
@@ -60,7 +60,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -202,7 +202,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-content-gateway-disabled.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-content-gateway-disabled.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -157,7 +157,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-content-gateway-with-defaults.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-content-gateway-with-defaults.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -227,7 +227,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-invalid-label-value.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-invalid-label-value.yaml
@@ -53,7 +53,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-invalid-tag-variable.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-invalid-tag-variable.yaml
@@ -53,7 +53,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-missing-label.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-missing-label.yaml
@@ -53,7 +53,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-on-empty.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-on-empty.yaml
@@ -52,7 +52,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-on-invalid-image-reference.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-on-invalid-image-reference.yaml
@@ -52,7 +52,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-rpm-not-in-mapping.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-rpm-not-in-mapping.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-tag-expansion.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-fail-tag-expansion.yaml
@@ -53,7 +53,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-flatpak-registries.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-flatpak-registries.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -215,7 +215,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-helm-chart.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-helm-chart.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -205,7 +205,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-implicit-timestamp-tag.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-implicit-timestamp-tag.yaml
@@ -49,7 +49,7 @@ spec:
               value: $(params.trustedArtifactsDebug)
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -167,7 +167,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-metadata.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-metadata.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -162,7 +162,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-multi-redhat-components.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-multi-redhat-components.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -197,7 +197,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-no-data-file.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-no-data-file.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -164,7 +164,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-no-data-mapping.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-no-data-mapping.yaml
@@ -52,7 +52,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -160,7 +160,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-no-metadata.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-no-metadata.yaml
@@ -56,7 +56,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -176,7 +176,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-other-formats.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-other-formats.yaml
@@ -51,7 +51,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -160,7 +160,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-rpm-content-type.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-rpm-content-type.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -162,7 +162,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-staged-files-expansion.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-staged-files-expansion.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -192,7 +192,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping-tag-expansion.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping-tag-expansion.yaml
@@ -50,7 +50,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -295,7 +295,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -199,7 +199,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/collect-data/collect-data.yaml
+++ b/tasks/managed/collect-data/collect-data.yaml
@@ -152,7 +152,7 @@ spec:
       runAsUser: 1001
   steps:
     - name: collect-data
-      image: quay.io/konflux-ci/release-service-utils@sha256:440c27f13adab931460a9371df82d3757b77f7ccc1b7604d737e0c78760a95c9
+      image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
       computeResources:
         limits:
           memory: 64Mi
@@ -261,14 +261,25 @@ spec:
         release_plan_admission_result=$(get-resource "releaseplanadmission" "${RELEASE_PLAN_ADMISSION}" \
             "{.spec.data}")
 
+        MERGE_FILE_1=$(mktemp)
+        MERGE_FILE_2=$(mktemp)
+        trap 'rm -f "${MERGE_FILE_1}" "${MERGE_FILE_2}"' EXIT
+
+        # Use file paths instead of string args to avoid ARG_MAX limits with large payloads
         # Merge collectors and Release keys. Release has higher priority
-        merged_output=$(merge-json "$collectors_result" "$release_result")
+        printf '%s' "${collectors_result}" > "${MERGE_FILE_1}"
+        printf '%s' "${release_result}" > "${MERGE_FILE_2}"
+        merged_output=$(merge-json "${MERGE_FILE_1}" "${MERGE_FILE_2}")
 
         # Merge now with ReleasePlan keys. ReleasePlan has higher priority
-        merged_output=$(merge-json "$merged_output" "$release_plan_result")
+        printf '%s' "${merged_output}" > "${MERGE_FILE_1}"
+        printf '%s' "${release_plan_result}" > "${MERGE_FILE_2}"
+        merged_output=$(merge-json "${MERGE_FILE_1}" "${MERGE_FILE_2}")
 
         # Finally merge with ReleasePlanAdmission keys. ReleasePlanAdmission has higher priority
-        merged_output=$(merge-json "$merged_output" "$release_plan_admission_result")
+        printf '%s' "${merged_output}" > "${MERGE_FILE_1}"
+        printf '%s' "${release_plan_admission_result}" > "${MERGE_FILE_2}"
+        merged_output=$(merge-json "${MERGE_FILE_1}" "${MERGE_FILE_2}")
 
         DATA_PATH="$(params.subdirectory)/data.json"
         echo -n "$DATA_PATH" > "$(results.data.path)"
@@ -321,7 +332,7 @@ spec:
         echo -n "${SNAPSHOT_NAMESPACE}" | tee "$(results.snapshotNamespace.path)"
 
     - name: check-data-key-sources
-      image: quay.io/konflux-ci/release-service-utils@sha256:440c27f13adab931460a9371df82d3757b77f7ccc1b7604d737e0c78760a95c9
+      image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
       computeResources:
         limits:
           memory: 32Mi

--- a/tasks/managed/collect-data/tests/test-collect-data-empty-component-group.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-empty-component-group.yaml
@@ -46,7 +46,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -199,7 +199,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -214,7 +214,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils@sha256:5546fa78d3c88d7b6a2e8cff8902f7757f00541d0bbaf113b9f293133894afa3
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-data/tests/test-collect-data-fail-disallowed-release.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-fail-disallowed-release.yaml
@@ -41,7 +41,7 @@ spec:
           env:
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils@sha256:440c27f13adab931460a9371df82d3757b77f7ccc1b7604d737e0c78760a95c9
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -164,7 +164,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils@sha256:440c27f13adab931460a9371df82d3757b77f7ccc1b7604d737e0c78760a95c9
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-data/tests/test-collect-data-fail-disallowed-releaseplan.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-fail-disallowed-releaseplan.yaml
@@ -41,7 +41,7 @@ spec:
           env:
         steps:
           - name: setup
-            image: quay.io/konflux-ci/release-service-utils@sha256:440c27f13adab931460a9371df82d3757b77f7ccc1b7604d737e0c78760a95c9
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -164,7 +164,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils@sha256:440c27f13adab931460a9371df82d3757b77f7ccc1b7604d737e0c78760a95c9
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-data/tests/test-collect-data-fail-missing-cr.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-fail-missing-cr.yaml
@@ -31,7 +31,7 @@ spec:
           env:
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils@sha256:440c27f13adab931460a9371df82d3757b77f7ccc1b7604d737e0c78760a95c9
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -116,7 +116,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils@sha256:440c27f13adab931460a9371df82d3757b77f7ccc1b7604d737e0c78760a95c9
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-data/tests/test-collect-data-fail-missing-rsc.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-fail-missing-rsc.yaml
@@ -31,7 +31,7 @@ spec:
           env:
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils@sha256:440c27f13adab931460a9371df82d3757b77f7ccc1b7604d737e0c78760a95c9
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -106,7 +106,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils@sha256:440c27f13adab931460a9371df82d3757b77f7ccc1b7604d737e0c78760a95c9
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-data/tests/test-collect-data-large-data.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-large-data.yaml
@@ -2,10 +2,11 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-collect-data-print-pipeline-ref
+  name: test-collect-data-large-data
 spec:
   description: |
-    Run the collect-data task and verify that the pipeline ref info is made available
+    Run the collect-data task with a large data (3000 CVEs + 3000 snapshot components)
+    to verify it handles ARG_MAX limits without "argument list too long" errors.
   params:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
@@ -48,98 +49,109 @@ spec:
             image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env bash
-              set -eux
+              set -euxo pipefail
 
               mkdir -p "$(params.dataDir)/$(context.pipelineRun.uid)"
-              cd "$(params.dataDir)/$(context.pipelineRun.uid)"
-              cat > release << EOF
-              apiVersion: appstudio.redhat.com/v1alpha1
-              kind: Release
-              metadata:
-                name: release-sample
-                namespace: default
-              spec:
-                snapshot: foo
-                releasePlan: foo
-              EOF
-              kubectl apply -f release
 
-              cat > releaseplan << EOF
+              # Generate release with 3000 CVEs in spec.data — large enough to exceed ARG_MAX
+              # when passed as a CLI argument (>128KB per argument on Linux)
+              jq -nc '{
+                "apiVersion": "appstudio.redhat.com/v1alpha1",
+                "kind": "Release",
+                "metadata": {"name": "release-large-sample", "namespace": "default"},
+                "spec": {
+                  "snapshot": "foo",
+                  "releasePlan": "foo",
+                  "data": {
+                    "releaseNotes": {
+                      "cves": [range(3000) | {
+                        "key": ("CVE-2024-" + (. + 10000 | tostring)),
+                        "component": ("component-" + (. | tostring))
+                      }]
+                    }
+                  }
+                }
+              }' > /tmp/release-large.json
+              kubectl apply -f /tmp/release-large.json
+
+              cat > /tmp/releaseplan << EOF
               apiVersion: appstudio.redhat.com/v1alpha1
               kind: ReleasePlan
               metadata:
-                name: releaseplan-sample
+                name: releaseplan-large-sample
                 namespace: default
               spec:
                 application: foo
                 target: foo
+                data:
+                  foo: bar
               EOF
-              kubectl apply -f releaseplan
+              kubectl apply -f /tmp/releaseplan
 
-              cat > releaseplanadmission << EOF
+              cat > /tmp/releaseplanadmission << EOF
               apiVersion: appstudio.redhat.com/v1alpha1
               kind: ReleasePlanAdmission
               metadata:
-                name: releaseplanadmission-sample
+                name: releaseplanadmission-large-sample
                 namespace: default
               spec:
                 applications:
                   - foo
                 origin: foo
+                data:
+                  singleComponentMode: false
                 policy: foo
                 pipeline:
                   pipelineRef:
+                    resolver: cluster
                     params:
-                      - name: url
-                        value: 'https://github.com/some-catalog/some-service-catalog.git'
-                      - name: revision
-                        value: development
-                      - name: pathInRepo
-                        value: pipelines/rh-advisories/rh-advisories.yaml
-                    resolver: git
-                  serviceAccountName: release-service-account
-                  timeouts:
-                    pipeline: 5h0m0s
+                      - name: name
+                        value: release-pipeline
+                      - name: namespace
+                        value: default
+                      - name: kind
+                        value: pipeline
               EOF
-              kubectl apply -f releaseplanadmission
+              kubectl apply -f /tmp/releaseplanadmission
 
-              cat > releaseserviceconfig << EOF
+              cat > /tmp/releaseserviceconfig << EOF
               apiVersion: appstudio.redhat.com/v1alpha1
               kind: ReleaseServiceConfig
               metadata:
-                name: releaseserviceconfig-sample
+                name: releaseserviceconfig-large-sample
                 namespace: default
               spec:
               EOF
-              kubectl apply -f releaseserviceconfig
+              kubectl apply -f /tmp/releaseserviceconfig
 
-              cat > snapshot << EOF
-              apiVersion: appstudio.redhat.com/v1alpha1
-              kind: Snapshot
-              metadata:
-                name: snapshot-sample
-                namespace: default
-              spec:
-                application: foo
-                components:
-                  - name: name
-                    containerImage: newimage
-              EOF
-              kubectl apply -f snapshot
+              # Generate snapshot with 3000 components to match large application use case
+              jq -nc '{
+                "apiVersion": "appstudio.redhat.com/v1alpha1",
+                "kind": "Snapshot",
+                "metadata": {"name": "snapshot-large-sample", "namespace": "default"},
+                "spec": {
+                  "application": "foo",
+                  "components": [range(3000) | {
+                    "name": ("component-" + (. | tostring)),
+                    "containerImage": "quay.io/example/image@sha256:abc123def456"
+                  }]
+                }
+              }' > /tmp/snapshot-large.json
+              kubectl apply -f /tmp/snapshot-large.json
     - name: run-task
       taskRef:
         name: collect-data
       params:
         - name: release
-          value: default/release-sample
+          value: default/release-large-sample
         - name: releasePlan
-          value: default/releaseplan-sample
+          value: default/releaseplan-large-sample
         - name: releasePlanAdmission
-          value: default/releaseplanadmission-sample
+          value: default/releaseplanadmission-large-sample
         - name: releaseServiceConfig
-          value: default/releaseserviceconfig-sample
+          value: default/releaseserviceconfig-large-sample
         - name: snapshot
-          value: default/snapshot-sample
+          value: default/snapshot-large-sample
         - name: subdirectory
           value: $(context.pipelineRun.uid)
         - name: orasOptions
@@ -158,8 +170,12 @@ spec:
         - setup
     - name: check-result
       params:
-        - name: releasePipelineMetadata
-          value: "$(tasks.run-task.results.releasePipelineMetadata)"
+        - name: data
+          value: $(tasks.run-task.results.data)
+        - name: snapshotSpec
+          value: $(tasks.run-task.results.snapshotSpec)
+        - name: singleComponentMode
+          value: $(tasks.run-task.results.singleComponentMode)
         - name: sourceDataArtifact
           value: "$(tasks.run-task.results.sourceDataArtifact)=$(params.dataDir)"
         - name: subdirectory
@@ -170,11 +186,15 @@ spec:
         - run-task
       taskSpec:
         params:
-          - name: releasePipelineMetadata
+          - name: data
             type: string
-          - name: subdirectory
+          - name: snapshotSpec
+            type: string
+          - name: singleComponentMode
             type: string
           - name: sourceDataArtifact
+            type: string
+          - name: subdirectory
             type: string
           - name: dataDir
             type: string
@@ -203,30 +223,26 @@ spec:
                 value: $(params.sourceDataArtifact)
           - name: check-result
             image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
-            env:
-              - name: PIPELINE_METADATA
-                value: '$(params.releasePipelineMetadata)'
             script: |
               #!/usr/bin/env bash
-              set -eux
+              set -euxo pipefail
 
-              if [ "$(wc -l < "$(params.dataDir)/mock_curl.txt")" != 1 ]; then
-                echo Error: curl was expected to be called 1 time. Actual calls:
-                cat "$(params.dataDir)/mock_curl.txt"
-                exit 1
-              fi
+              echo Test that data.json was created
+              test -f "$(params.dataDir)/$(params.data)"
 
-              org=$(jq -r '.org' <<< "$PIPELINE_METADATA")
-              repo=$(jq -r '.repo' <<< "$PIPELINE_METADATA")
-              revision=$(jq -r '.revision' <<< "$PIPELINE_METADATA")
-              pathinrepo=$(jq -r '.pathinrepo' <<< "$PIPELINE_METADATA")
-              sha=$(jq -r '.sha' <<< "$PIPELINE_METADATA")
+              echo Test that all 3000 CVEs are present in merged data
+              CVE_COUNT=$(jq '.releaseNotes.cves | length' "$(params.dataDir)/$(params.data)")
+              test "${CVE_COUNT}" -eq 3000
 
-              test "${org}" == 'some-catalog'
-              test "${repo}" == 'some-service-catalog'
-              test "${revision}" == 'development'
-              test "${pathinrepo}" == 'pipelines/rh-advisories/rh-advisories.yaml'
-              test "${sha}" == '12345'
+              echo Test that ReleasePlan data was merged correctly
+              test "$(jq -r '.foo' "$(params.dataDir)/$(params.data)")" == "bar"
+
+              echo Test that singleComponentMode result was set from ReleasePlanAdmission
+              test "$(params.singleComponentMode)" == "false"
+
+              echo Test that snapshot_spec.json has all 3000 components
+              COMPONENT_COUNT=$(jq '.components | length' "$(params.dataDir)/$(params.snapshotSpec)")
+              test "${COMPONENT_COUNT}" -eq 3000
 
   finally:
     - name: cleanup
@@ -236,10 +252,10 @@ spec:
             image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env sh
-              set -eux
+              set -euxo pipefail
 
-              kubectl delete release release-sample
-              kubectl delete releaseplan releaseplan-sample
-              kubectl delete releaseplanadmission releaseplanadmission-sample
-              kubectl delete releaseserviceconfig releaseserviceconfig-sample
-              kubectl delete snapshot snapshot-sample
+              kubectl delete release release-large-sample
+              kubectl delete releaseplan releaseplan-large-sample
+              kubectl delete releaseplanadmission releaseplanadmission-large-sample
+              kubectl delete releaseserviceconfig releaseserviceconfig-large-sample
+              kubectl delete snapshot snapshot-large-sample

--- a/tasks/managed/collect-data/tests/test-collect-data-print-pipeline-ref-nongit.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-print-pipeline-ref-nongit.yaml
@@ -46,7 +46,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils@sha256:440c27f13adab931460a9371df82d3757b77f7ccc1b7604d737e0c78760a95c9
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -207,7 +207,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:440c27f13adab931460a9371df82d3757b77f7ccc1b7604d737e0c78760a95c9
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             env:
               - name: PIPELINE_METADATA
                 value: '$(params.releasePipelineMetadata)'
@@ -240,7 +240,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils@sha256:440c27f13adab931460a9371df82d3757b77f7ccc1b7604d737e0c78760a95c9
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-data/tests/test-collect-data-tags.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-tags.yaml
@@ -45,7 +45,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils@sha256:440c27f13adab931460a9371df82d3757b77f7ccc1b7604d737e0c78760a95c9
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -250,7 +250,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:440c27f13adab931460a9371df82d3757b77f7ccc1b7604d737e0c78760a95c9
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -264,7 +264,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils@sha256:440c27f13adab931460a9371df82d3757b77f7ccc1b7604d737e0c78760a95c9
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-data/tests/test-collect-data-with-data-and-collectors.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-with-data-and-collectors.yaml
@@ -45,7 +45,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils@sha256:440c27f13adab931460a9371df82d3757b77f7ccc1b7604d737e0c78760a95c9
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -221,7 +221,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:440c27f13adab931460a9371df82d3757b77f7ccc1b7604d737e0c78760a95c9
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -242,7 +242,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils@sha256:440c27f13adab931460a9371df82d3757b77f7ccc1b7604d737e0c78760a95c9
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-data/tests/test-collect-data-with-data-and-no-collectors.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-with-data-and-no-collectors.yaml
@@ -45,7 +45,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils@sha256:440c27f13adab931460a9371df82d3757b77f7ccc1b7604d737e0c78760a95c9
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -213,7 +213,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:440c27f13adab931460a9371df82d3757b77f7ccc1b7604d737e0c78760a95c9
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -232,7 +232,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils@sha256:440c27f13adab931460a9371df82d3757b77f7ccc1b7604d737e0c78760a95c9
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-data/tests/test-collect-data-with-data-merging-collectors.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data-with-data-merging-collectors.yaml
@@ -46,7 +46,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils@sha256:440c27f13adab931460a9371df82d3757b77f7ccc1b7604d737e0c78760a95c9
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -214,7 +214,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:440c27f13adab931460a9371df82d3757b77f7ccc1b7604d737e0c78760a95c9
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -230,7 +230,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils@sha256:440c27f13adab931460a9371df82d3757b77f7ccc1b7604d737e0c78760a95c9
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env sh
               set -eux

--- a/tasks/managed/collect-data/tests/test-collect-data.yaml
+++ b/tasks/managed/collect-data/tests/test-collect-data.yaml
@@ -45,7 +45,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: create-crs
-            image: quay.io/konflux-ci/release-service-utils@sha256:440c27f13adab931460a9371df82d3757b77f7ccc1b7604d737e0c78760a95c9
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -237,7 +237,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:440c27f13adab931460a9371df82d3757b77f7ccc1b7604d737e0c78760a95c9
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -278,7 +278,7 @@ spec:
       taskSpec:
         steps:
           - name: delete-crs
-            image: quay.io/konflux-ci/release-service-utils@sha256:440c27f13adab931460a9371df82d3757b77f7ccc1b7604d737e0c78760a95c9
+            image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone:on-pr-38a5e4c5897377e038b66648055a625602383cda
             script: |
               #!/usr/bin/env sh
               set -eux


### PR DESCRIPTION


## Describe your changes
Passing large JSON strings as CLI arguments hits the kernel's MAX_ARG_STRLEN limit (~128KB per arg)

Write each JSON input to a temp file via printf
and pass the file paths to merge-json
instead.

Assisted-by: Claude
## Relevant Jira

Depends on: https://github.com/konflux-ci/release-service-utils/pull/986
Slack: https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1787752162085179
## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
