### PR TITLE
fix: correct calunga snapshot path

### DIFF
--- a/pipelines/managed/calunga-push-to-pulp/calunga-push-to-pulp.yaml
+++ b/pipelines/managed/calunga-push-to-pulp/calunga-push-to-pulp.yaml
@@ -186,7 +186,7 @@ spec:
             value: tasks/managed/reduce-snapshot/reduce-snapshot.yaml
       params:
         - name: SNAPSHOT
-          value: $(workspaces.data.path)/$(tasks.collect-data.results.snapshotSpec)
+          value: $(params.dataDir)/$(tasks.collect-data.results.snapshotSpec)
         - name: SINGLE_COMPONENT
           value: $(tasks.collect-data.results.singleComponentMode)
         - name: SINGLE_COMPONENT_CUSTOM_RESOURCE
@@ -194,7 +194,7 @@ spec:
         - name: SINGLE_COMPONENT_CUSTOM_RESOURCE_NS
           value: $(tasks.collect-data.results.snapshotNamespace)
         - name: SNAPSHOT_PATH
-          value: $(workspaces.data.path)/$(tasks.collect-data.results.snapshotSpec)
+          value: $(params.dataDir)/$(tasks.collect-data.results.snapshotSpec)
         - name: taskGitUrl
           value: $(params.taskGitUrl)
         - name: taskGitRevision
@@ -203,6 +203,8 @@ spec:
           value: "$(tasks.collect-data.results.sourceDataArtifact)"
         - name: ociStorage
           value: $(tasks.config.results.ociStorage)
+        - name: dataDir
+          value: $(params.dataDir)
       runAfter:
         - collect-data
     - name: verify-enterprise-contract


### PR DESCRIPTION
## Describe your changes

Fix `calunga-push-to-pulp` snapshot path handling in the `reduce-snapshot` task.

The pipeline passed an undeclared workspace variable:

```yaml
$(workspaces.data.path)/$(tasks.collect-data.results.snapshotSpec)
```

Because this pipeline has no `data` workspace, Tekton passed that value literally instead of resolving it to a
filesystem path.

This was previously hidden by the `reduce-snapshot` implementation: its `reduce` step could exit non-zero but used
`onError: continue`, allowing the pipeline to proceed with an unreduced snapshot.

The recent [`reduce-snapshot` Python conversion](https://github.com/konflux-ci/release-service-catalog/commit/194e10c376846adadb08bd1472a004ee8866a482)
removed that error suppression. The same invalid path then correctly caused `reduce-snapshot` to fail.

This PR fixes the underlying wiring:

- Use `$(params.dataDir)/$(tasks.collect-data.results.snapshotSpec)` for `SNAPSHOT` and `SNAPSHOT_PATH`.
- Pass `dataDir` explicitly to `reduce-snapshot`, ensuring the restored trusted artifact and snapshot path use the
  same location.

## Relevant Jira

N/A — fixes pre-existing pipeline wiring exposed by the `reduce-snapshot` implementation change.

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
