### PR TITLE
fix(KFLUXSPRT-8832): derive CGW content dir per-component

### DIFF
--- a/tasks/internal/pulp-push-disk-images/pulp-push-disk-images.yaml
+++ b/tasks/internal/pulp-push-disk-images/pulp-push-disk-images.yaml
@@ -350,7 +350,7 @@ spec:
         for ((i = 0; i < NUM_COMPONENTS; i++)) ; do
             COMPONENT=$(jq -c --arg i "$i" '.components[$i|tonumber]' <<< "$SNAPSHOT_JSON")
             # Derive the content directory from this component's own staged.destination.
-            # Do NOT index a separate array built from find/staged-file order: that order
+            # Do not index a separate array built from find/staged-file order: that order
             # does not track component order, so components get paired with the wrong
             # directory and their files are skipped (never published to the Developer Portal).
             CONTENT_DIR="${DISK_IMAGE_DIR}/$(jq -er '.staged.destination' <<< "$COMPONENT")/FILES"

--- a/tasks/internal/pulp-push-disk-images/pulp-push-disk-images.yaml
+++ b/tasks/internal/pulp-push-disk-images/pulp-push-disk-images.yaml
@@ -344,19 +344,16 @@ spec:
           --pulp-task-timeout-seconds "$(params.pulpTaskTimeout)" \
           2> >(tee -a "$STDERR_FILE" >&2)
 
-        relative_paths=$(echo "$STAGED_JSON" | jq -erc .payload.files[].relative_path)
-        component_destinations=()
-        for path in $relative_paths:
-        do
-          parent_dir=$(dirname "$path")
-          component_destinations+=("${DISK_IMAGE_DIR}/$parent_dir")
-        done
-
         ## Process Files for Developer Portal / CGW
         ##
         NUM_COMPONENTS=$(jq '.components | length' <<< "$SNAPSHOT_JSON")
         for ((i = 0; i < NUM_COMPONENTS; i++)) ; do
             COMPONENT=$(jq -c --arg i "$i" '.components[$i|tonumber]' <<< "$SNAPSHOT_JSON")
-            process_component_for_developer_portal "$COMPONENT" "${component_destinations[$i]}" \
+            # Derive the content directory from this component's own staged.destination.
+            # Do NOT index a separate array built from find/staged-file order: that order
+            # does not track component order, so components get paired with the wrong
+            # directory and their files are skipped (never published to the Developer Portal).
+            CONTENT_DIR="${DISK_IMAGE_DIR}/$(jq -er '.staged.destination' <<< "$COMPONENT")/FILES"
+            process_component_for_developer_portal "$COMPONENT" "$CONTENT_DIR" \
               2> >(tee -a "$STDERR_FILE" >&2)
         done


### PR DESCRIPTION
## What
Fix the Developer Portal / CGW publish loop in `pulp-push-disk-images` so each
component is paired with its own content directory.

## Why
The loop built `component_destinations` from `STAGED_JSON.payload.files[]`, whose
order comes from `find * -type f` (filesystem order), then indexed it by component
index `i`. Those two orders do not match, so components were handed the wrong
content directory. The `developer_portal_wrapper` then filtered that directory by
the component's `--file-prefix`, matched nothing, and skipped the files — so they
were never published to the Developer Portal (though their blobs were still pushed
to CGW by `pulp_push_wrapper`, hence "visible in CGW admin, absent on the portal").

Observed on RHEL AI 3.4.4: cuda-aws and cuda-azure (x86_64) ran against the
aarch64 dir, and the two aarch64 cuda components ran against the x86_64 dir →
4 of 10 files never got a portal entry.

## Fix
Derive the content directory from each component's own `.staged.destination`,
matching the staging loop (and the `pulp_push_disk_images.py` rewrite in
release-service-utils). Drop the desynced array and the stray `for path in $relative_paths:` colon.


Assisted-by: Claude Opus 4.8 (1M context)

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [x] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
