### PR TITLE
fix(CALUNGA-396): enable home dir to be writable for quay token copy

### DIFF
--- a/tasks/managed/extract-npm-artifacts/extract-npm-artifacts.yaml
+++ b/tasks/managed/extract-npm-artifacts/extract-npm-artifacts.yaml
@@ -73,6 +73,10 @@ spec:
     securityContext:
       runAsUser: 1001
     env:
+      # Writable HOME so Tekton creds-init can copy SA dockerconfig secrets to
+      # $HOME/.docker/config.json (select-oci-auth in plumbing-utils).
+      - name: HOME
+        value: /var/workdir
       - name: SNAPSHOT_PATH
         value: $(params.SNAPSHOT_PATH)
       - name: IMAGES_TXT

--- a/tasks/managed/upload-npm-closure/upload-npm-closure.yaml
+++ b/tasks/managed/upload-npm-closure/upload-npm-closure.yaml
@@ -78,6 +78,10 @@ spec:
     securityContext:
       runAsUser: 1001
     env:
+      # Writable HOME so Tekton creds-init can copy SA dockerconfig secrets to
+      # $HOME/.docker/config.json (select-oci-auth in plumbing-utils).
+      - name: HOME
+        value: /var/workdir
       - name: PULP_BASE_URL
         value: $(params.PULP_BASE_URL)
       - name: PULP_API_ROOT


### PR DESCRIPTION
## Describe your changes
Two tasks fail to copy token for quay from secret due to file system write access. This is causing quay operations to fail.

## Relevant Jira
https://redhat.atlassian.net/browse/CALUNGA-396

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [x] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [x] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
