### PR TITLE
chore: bump utils image in update-infra-deployments task

### DIFF
--- a/tasks/managed/update-infra-deployments/tests/test-update-infra-deployments.yaml
+++ b/tasks/managed/update-infra-deployments/tests/test-update-infra-deployments.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:4883a99413e3424a5f5eec8dbca63c2e40e58ab02d809f373d23fcd9c49b58a8
+            image: quay.io/konflux-ci/release-service-utils@sha256:85eef5b03d40aac1abba9ca70feb20a4272fc6e0c77c60586edbc50ebbb78111
             script: |
               #!/usr/bin/env bash
               set -eux

--- a/tasks/managed/update-infra-deployments/update-infra-deployments.yaml
+++ b/tasks/managed/update-infra-deployments/update-infra-deployments.yaml
@@ -132,7 +132,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: update-infra-deployments
-      image: quay.io/konflux-ci/release-service-utils@sha256:4883a99413e3424a5f5eec8dbca63c2e40e58ab02d809f373d23fcd9c49b58a8
+      image: quay.io/konflux-ci/release-service-utils@sha256:85eef5b03d40aac1abba9ca70feb20a4272fc6e0c77c60586edbc50ebbb78111
       computeResources:
         limits:
           memory: 512Mi


### PR DESCRIPTION
The updated image includes a change to return None instead of raise RunTimeError when there are unresolvable merge commits.

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
