### PR TITLE
feat(KFLUXSPRT-8900): give push-artifacts-to-cdn a 200Gi vol

### DIFF
--- a/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
@@ -110,7 +110,14 @@ spec:
       description: List of published files
   volumes:
     - name: shared-dir
-      emptyDir: {}
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 200Gi
     - name: mac-ssh-key-vol
       secret:
         secretName: mac-ssh-key
@@ -238,6 +245,8 @@ spec:
           value: $(results.checksum_map.path)
         - name: RESULT_PUBLISHED_FILES
           value: $(results.publishedFiles.path)
+        - name: TMPDIR
+          value: /shared
       command:
         - python3
       args:

--- a/tasks/internal/push-artifacts-to-cdn-task/tests/pre-apply-task-hook.sh
+++ b/tasks/internal/push-artifacts-to-cdn-task/tests/pre-apply-task-hook.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 
-set -ex
+set -euxo pipefail
+
+TASK_PATH="$1"
+
+# Kind cannot usefully provision 200Gi. Shrink the ephemeral PVC for task tests.
+STORAGE_PATH=".spec.volumes[] | select(.name == \"shared-dir\")"
+STORAGE_PATH="${STORAGE_PATH}.ephemeral.volumeClaimTemplate.spec.resources.requests.storage"
+yq -i "(${STORAGE_PATH}) = \"1Gi\"" "${TASK_PATH}"
 
 # Create redhat-workloads-token secret used by extract_artifacts for docker auth
 kubectl delete secret redhat-workloads-token --ignore-not-found


### PR DESCRIPTION
Replace the shared emptyDir with an ephemeral PVC and set TMPDIR=/shared so skopeo copy and extract have enough disk for a 64Gi ISO plus image layers.

Assisted-by: Cursor AI

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
