### PR TITLE
fix(KFLUXSPRT-8832): raise pulp-push-disk-images memory to 4Gi

### DIFF
--- a/tasks/internal/pulp-push-disk-images/pulp-push-disk-images.yaml
+++ b/tasks/internal/pulp-push-disk-images/pulp-push-disk-images.yaml
@@ -95,9 +95,9 @@ spec:
       image: quay.io/konflux-ci/release-service-utils@sha256:a91acd22c0d064dd34d183457a844aae82fb48b647d46c27f2f0dbe61b461409
       computeResources:
         limits:
-          memory: 512Mi
+          memory: 4Gi
         requests:
-          memory: 512Mi
+          memory: 4Gi
           cpu: 450m
       volumeMounts:
         - name: exodus-gw-secret


### PR DESCRIPTION
The inner task was OOMKilled at 512Mi while pulling three concurrent disk images. Keep limits and requests equal.



Assisted-by: Cursor AI

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
