### PR TITLE
fix(KFLUXSPRT-8616): pin push-artifacts-to-cdn to released utils

### DIFF
--- a/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
@@ -179,7 +179,7 @@ spec:
 
   steps:
     - name: push-artifacts-to-cdn
-      image: quay.io/konflux-ci/release-service-utils@sha256:2ae61d5886887b230860934bfc7719453e44bc8882fab5ad84a483a720c5763d
+      image: quay.io/konflux-ci/release-service-utils@sha256:b280c6a004ff1be679970ac5fd3839ae9e9aef30ece34d626b821a7b4dc8c0c4
       securityContext:
         runAsUser: 1001
       computeResources:


### PR DESCRIPTION
## Summary

Updates `push-artifacts-to-cdn-task` to the released `release-service-utils`
image containing the fix from
[konflux-ci/release-service-utils#940](https://github.com/konflux-ci/release-service-utils/pull/940),
now merged.

[#940](https://github.com/konflux-ci/release-service-utils/pull/940) fixes a bug
where components with multiple file entries sharing the same `(os, arch)` tuple
(e.g. rhel8/rhel9 Linux/amd64 variants) overwrote each other during unpack, and
a follow-up collision in advisory PURL generation.

This PR was originally opened as a draft to validate the fix end-to-end against
the CDN push path using #940's PR-build image before it merged. All checks
passed, #940 is now merged, and this PR is updated to pin the canonical
released image digest instead.

## Testing

`push-artifacts-to-cdn-e2e-test` passed against the PR-build image during
validation; re-running now against the canonical released digest.

## Checklist

- [x] Validated against #940's PR-build image (all checks green)
- [x] #940 merged
- [x] Updated to the canonical released utils image digest
- [ ] CI passes on this commit

Made with [Cursor](https://cursor.com)