### PR TITLE
fix: bump release-service-utils image in direct signing tasks

### DIFF
--- a/tasks/managed/direct-sign-index-image/direct-sign-index-image.yaml
+++ b/tasks/managed/direct-sign-index-image/direct-sign-index-image.yaml
@@ -163,7 +163,7 @@ spec:
         - name: sourceDataArtifact
           value: $(params.sourceDataArtifact)
     - name: direct-sign-index-image
-      image: quay.io/konflux-ci/release-service-utils@sha256:19b51294e8faf4db356d1c5ba45dd575fece40fcde081152fe4842d3e1bbb232
+      image: quay.io/konflux-ci/release-service-utils@sha256:52379c67669f9901579473421c5ad231b40ddbface581a7e87a2afe45caac7b5
       computeResources:
         limits:
           memory: 1Gi

--- a/tasks/managed/direct-sign-index-image/tests/test-direct-sign-index-image.yaml
+++ b/tasks/managed/direct-sign-index-image/tests/test-direct-sign-index-image.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:19b51294e8faf4db356d1c5ba45dd575fece40fcde081152fe4842d3e1bbb232
+            image: quay.io/konflux-ci/release-service-utils@sha256:52379c67669f9901579473421c5ad231b40ddbface581a7e87a2afe45caac7b5
             script: |
               #!/usr/bin/env bash
               set -eux
@@ -148,7 +148,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:19b51294e8faf4db356d1c5ba45dd575fece40fcde081152fe4842d3e1bbb232
+            image: quay.io/konflux-ci/release-service-utils@sha256:52379c67669f9901579473421c5ad231b40ddbface581a7e87a2afe45caac7b5
             script: |
               #!/usr/bin/env bash
               set -euxo pipefail

--- a/tasks/managed/rh-direct-sign-image/rh-direct-sign-image.yaml
+++ b/tasks/managed/rh-direct-sign-image/rh-direct-sign-image.yaml
@@ -170,7 +170,7 @@ spec:
           value: $(params.sourceDataArtifact)
 
     - name: sign-image
-      image: quay.io/konflux-ci/release-service-utils@sha256:19b51294e8faf4db356d1c5ba45dd575fece40fcde081152fe4842d3e1bbb232
+      image: quay.io/konflux-ci/release-service-utils@sha256:52379c67669f9901579473421c5ad231b40ddbface581a7e87a2afe45caac7b5
       computeResources:
         limits:
           memory: 4Gi

--- a/tasks/managed/rh-direct-sign-image/tests/mocks/kubectl
+++ b/tasks/managed/rh-direct-sign-image/tests/mocks/kubectl
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Mock kubectl that intercepts InternalRequest API calls and delegates the rest.
+# The sign-image step calls kubectl for two purposes:
+#   1. get_configmap() — fetching the signing ConfigMap (must reach real API)
+#   2. internal_request — creating and polling InternalRequests (mocked here)
+_self_dir="$(cd "$(dirname "$0")" && pwd)"
+_real=""
+IFS=: read -ra _dirs <<< "$PATH"
+for _d in "${_dirs[@]}"; do
+    if [ "$_d" != "$_self_dir" ] && [ -x "$_d/kubectl" ]; then
+        _real="$_d/kubectl"
+        break
+    fi
+done
+
+case "$1" in
+    create)
+        if [ "$2" = "-f" ] && [ "$3" = "-" ]; then
+            # kubectl create -f - -o json (InternalRequest creation)
+            payload=$(cat)
+            echo "$payload" >> "${DATA_DIR}/mock_internal_request.txt"
+            echo "{\"metadata\": {\"name\": \"mock-ir-$$\"}}"
+            exit 0
+        fi
+        exec "$_real" "$@"
+        ;;
+    get)
+        if [ "$2" = "internalrequest" ]; then
+            ir_name="$3"
+            if echo "$@" | grep -q "jsonpath"; then
+                echo '{}'
+            elif echo "$@" | grep -q -- "-l "; then
+                echo '{"items": []}'
+            else
+                echo "{\"metadata\":{\"name\":\"${ir_name}\"},\"status\":{\"conditions\":[{\"reason\":\"Succeeded\"}],\"pipelineRun\":\"mock-pr-1\"}}"
+            fi
+            exit 0
+        fi
+        exec "$_real" "$@"
+        ;;
+    delete)
+        if [ "$2" = "internalrequest" ]; then
+            echo "internalrequest.appstudio.redhat.com \"$3\" deleted"
+            exit 0
+        fi
+        exec "$_real" "$@"
+        ;;
+    *)
+        exec "$_real" "$@"
+        ;;
+esac

--- a/tasks/managed/rh-direct-sign-image/tests/test-rh-direct-sign-image.yaml
+++ b/tasks/managed/rh-direct-sign-image/tests/test-rh-direct-sign-image.yaml
@@ -47,7 +47,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:19b51294e8faf4db356d1c5ba45dd575fece40fcde081152fe4842d3e1bbb232
+            image: quay.io/konflux-ci/release-service-utils@sha256:52379c67669f9901579473421c5ad231b40ddbface581a7e87a2afe45caac7b5
             script: |
               #!/usr/bin/env bash
               set -euxo pipefail
@@ -161,31 +161,31 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:19b51294e8faf4db356d1c5ba45dd575fece40fcde081152fe4842d3e1bbb232
+            image: quay.io/konflux-ci/release-service-utils@sha256:52379c67669f9901579473421c5ad231b40ddbface581a7e87a2afe45caac7b5
             script: |
               #!/usr/bin/env bash
               set -euxo pipefail
 
               mock_file="$(params.dataDir)/mock_internal_request.txt"
               if [ ! -f "${mock_file}" ]; then
-                echo "Error: internal-request was not called"
+                echo "Error: no InternalRequest was created"
                 exit 1
               fi
 
-              args=$(cat "${mock_file}")
+              payload=$(cat "${mock_file}")
 
-              if ! echo "${args}" | grep -q -- "--pipeline container-signing"; then
-                echo "Expected --pipeline container-signing in args: ${args}"
+              if ! echo "${payload}" | grep -q '"generateName":.*"container-signing-"'; then
+                echo "Expected generateName 'container-signing-' in payload"
                 exit 1
               fi
 
-              if ! echo "${args}" | grep -q "signing_requests="; then
-                echo "Expected signing_requests= in args: ${args}"
+              if ! echo "${payload}" | grep -q '"signing_requests"'; then
+                echo "Expected signing_requests param in payload"
                 exit 1
               fi
 
-              if ! echo "${args}" | grep -q "requester=testuser"; then
-                echo "Expected requester=testuser in args: ${args}"
+              if ! echo "${payload}" | grep -q '"requester":.*"testuser"'; then
+                echo "Expected requester=testuser in payload"
                 exit 1
               fi
 


### PR DESCRIPTION
## Describe your changes
Bumping [release-service-utils](https://issues.redhat.com/browse/RELEASE-service-utils) to reflect latest logging changes.

## Relevant Jira
https://github.com/konflux-ci/release-service-utils/pull/992

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
