### PR TITLE
fix(KFLUXSPRT-8832): disk-image OOM and CGW dir fix

### DIFF
--- a/tasks/internal/pulp-push-disk-images/pulp-push-disk-images.yaml
+++ b/tasks/internal/pulp-push-disk-images/pulp-push-disk-images.yaml
@@ -95,9 +95,9 @@ spec:
       image: quay.io/konflux-ci/release-service-utils@sha256:a91acd22c0d064dd34d183457a844aae82fb48b647d46c27f2f0dbe61b461409
       computeResources:
         limits:
-          memory: 512Mi
+          memory: 4Gi
         requests:
-          memory: 512Mi
+          memory: 4Gi
           cpu: 450m
       volumeMounts:
         - name: exodus-gw-secret
@@ -344,19 +344,16 @@ spec:
           --pulp-task-timeout-seconds "$(params.pulpTaskTimeout)" \
           2> >(tee -a "$STDERR_FILE" >&2)
 
-        relative_paths=$(echo "$STAGED_JSON" | jq -erc .payload.files[].relative_path)
-        component_destinations=()
-        for path in $relative_paths:
-        do
-          parent_dir=$(dirname "$path")
-          component_destinations+=("${DISK_IMAGE_DIR}/$parent_dir")
-        done
-
         ## Process Files for Developer Portal / CGW
         ##
         NUM_COMPONENTS=$(jq '.components | length' <<< "$SNAPSHOT_JSON")
         for ((i = 0; i < NUM_COMPONENTS; i++)) ; do
             COMPONENT=$(jq -c --arg i "$i" '.components[$i|tonumber]' <<< "$SNAPSHOT_JSON")
-            process_component_for_developer_portal "$COMPONENT" "${component_destinations[$i]}" \
+            # Derive the content directory from this component's own staged.destination.
+            # Do not index a separate array built from find/staged-file order: that order
+            # does not track component order, so components get paired with the wrong
+            # directory and their files are skipped (never published to the Developer Portal).
+            CONTENT_DIR="${DISK_IMAGE_DIR}/$(jq -er '.staged.destination' <<< "$COMPONENT")/FILES"
+            process_component_for_developer_portal "$COMPONENT" "$CONTENT_DIR" \
               2> >(tee -a "$STDERR_FILE" >&2)
         done


### PR DESCRIPTION
## Describe your changes
The 3 commits on this branch have been tested by RHELAI in their most recent disk-image release.
- derive Content Gateway dir per-component
- raise disk image task memory to 4Gi


## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
