### PR TITLE
fix: make /agentic_review default

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -7,13 +7,11 @@
 ignore_pr_authors = ["red-hat-konflux", "release-service-bot"]
 # Run review automatically when PRs are opened/reopened/ready.
 pr_commands = [
-  "/review",
   "/agentic_review",
 ]
 # Run review automatically when new commits are pushed to an open PR.
 handle_push_trigger = true
 push_commands = [
-  "/review",
   "/agentic_review",
 ]
 


### PR DESCRIPTION
Qodo /review command uses older version of the agent that does not auto resolve qodo comments on code fix or replies. This makes it similar to `release-service-utils` repo, that uses `agentic_review` by default.
## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
