### PR TITLE
chore(RELEASE-2116): disable retries on e2e test RPAs

### DIFF
--- a/integration-tests/collectors/resources/managed/rpa.yaml
+++ b/integration-tests/collectors/resources/managed/rpa.yaml
@@ -41,6 +41,7 @@ spec:
       product_stream: comp2-1.0
   origin: ${tenant_namespace}
   pipeline:
+    maxRetries: 0
     pipelineRef:
       params:
         - name: url

--- a/integration-tests/e2e/resources/managed/rpa.yaml
+++ b/integration-tests/e2e/resources/managed/rpa.yaml
@@ -18,6 +18,7 @@ spec:
                 - '{{ git_short_sha }}'
   origin: ${tenant_namespace}
   pipeline:
+    maxRetries: 0
     pipelineRef:
       params:
         - name: url

--- a/integration-tests/fbc-release/resources/managed/rpa.yaml
+++ b/integration-tests/fbc-release/resources/managed/rpa.yaml
@@ -32,6 +32,7 @@ spec:
       cosignSecretName: "konflux-cosign-signing-stage-${component_name}"
   origin: ${tenant_namespace}
   pipeline:
+    maxRetries: 0
     pipelineRef:
       params:
         - name: url
@@ -80,6 +81,7 @@ spec:
       cosignSecretName: "konflux-cosign-signing-stage-${component_name}"
   origin: ${tenant_namespace}
   pipeline:
+    maxRetries: 0
     pipelineRef:
       params:
         - name: url
@@ -128,6 +130,7 @@ spec:
       cosignSecretName: "konflux-cosign-signing-stage-${component_name}"
   origin: ${tenant_namespace}
   pipeline:
+    maxRetries: 0
     pipelineRef:
       params:
         - name: url
@@ -176,6 +179,7 @@ spec:
       cosignSecretName: "konflux-cosign-signing-stage-${component_name}"
   origin: ${tenant_namespace}
   pipeline:
+    maxRetries: 0
     pipelineRef:
       params:
         - name: url
@@ -217,6 +221,7 @@ spec:
       cosignSecretName: "konflux-cosign-signing-stage-${component_name}"
   origin: ${tenant_namespace}
   pipeline:
+    maxRetries: 0
     pipelineRef:
       params:
         - name: url
@@ -258,6 +263,7 @@ spec:
       cosignSecretName: "konflux-cosign-signing-stage-${component_name}"
   origin: ${tenant_namespace}
   pipeline:
+    maxRetries: 0
     pipelineRef:
       params:
         - name: url

--- a/integration-tests/push-artifacts-to-cdn/resources/managed/rpa.yaml
+++ b/integration-tests/push-artifacts-to-cdn/resources/managed/rpa.yaml
@@ -122,6 +122,7 @@ spec:
       configMapName: "hacbs-signing-pipeline-config-staging-e2e"
   origin: ${tenant_namespace}
   pipeline:
+    maxRetries: 0
     pipelineRef:
       params:
         - name: url

--- a/integration-tests/push-disk-images/resources/managed/rpa.yaml
+++ b/integration-tests/push-disk-images/resources/managed/rpa.yaml
@@ -31,6 +31,7 @@ spec:
             filePrefix: "push-disk-images-e2e"
   origin: ${tenant_namespace}
   pipeline:
+    maxRetries: 0
     pipelineRef:
       params:
         - name: url

--- a/integration-tests/push-rpms-to-pulp/resources/managed/rpa.yaml
+++ b/integration-tests/push-rpms-to-pulp/resources/managed/rpa.yaml
@@ -84,6 +84,7 @@ spec:
       type: "RHBA"
   origin: ${tenant_namespace}
   pipeline:
+    maxRetries: 0
     pipelineRef:
       params:
         - name: url

--- a/integration-tests/push-to-addons-registry/resources/managed/rpa.yaml
+++ b/integration-tests/push-to-addons-registry/resources/managed/rpa.yaml
@@ -44,6 +44,7 @@ spec:
           pushSourceContainer: false
   origin: ${tenant_namespace}
   pipeline:
+    maxRetries: 0
     pipelineRef:
       params:
         - name: url

--- a/integration-tests/push-to-external-registry-idempotent/resources/managed/rpa.yaml
+++ b/integration-tests/push-to-external-registry-idempotent/resources/managed/rpa.yaml
@@ -32,6 +32,7 @@ spec:
                 - '{{ git_short_sha }}'
   origin: ${tenant_namespace}
   pipeline:
+    maxRetries: 0
     pipelineRef:
       params:
         - name: url

--- a/integration-tests/push-to-external-registry-self-hosted-quay/resources/managed/rpa.yaml
+++ b/integration-tests/push-to-external-registry-self-hosted-quay/resources/managed/rpa.yaml
@@ -22,6 +22,7 @@ spec:
       registrySecret: quay-api-token
   origin: ${tenant_namespace}
   pipeline:
+    maxRetries: 0
     pipelineRef:
       params:
         - name: url

--- a/integration-tests/push-to-external-registry/resources/managed/rpa.yaml
+++ b/integration-tests/push-to-external-registry/resources/managed/rpa.yaml
@@ -33,6 +33,7 @@ spec:
                 - 'v1.0.0-{{ component-incrementer }}'
   origin: ${tenant_namespace}
   pipeline:
+    maxRetries: 0
     pipelineRef:
       params:
         - name: url

--- a/integration-tests/release-to-github/resources/managed/rpa.yaml
+++ b/integration-tests/release-to-github/resources/managed/rpa.yaml
@@ -33,6 +33,7 @@ spec:
     intention: staging
   origin: ${tenant_namespace}
   pipeline:
+    maxRetries: 0
     pipelineRef:
       params:
         - name: url

--- a/integration-tests/rh-advisories-idempotent/resources/managed/rpa.yaml
+++ b/integration-tests/rh-advisories-idempotent/resources/managed/rpa.yaml
@@ -41,6 +41,7 @@ spec:
       product_stream: comp2-1.0
   origin: ${tenant_namespace}
   pipeline:
+    maxRetries: 0
     pipelineRef:
       params:
         - name: url

--- a/integration-tests/rh-advisories-large-snapshot/resources/managed/rpa.yaml
+++ b/integration-tests/rh-advisories-large-snapshot/resources/managed/rpa.yaml
@@ -82,6 +82,7 @@ spec:
       jiraAdvisorySecret: advisory-jira-secret-${component_name}
   origin: ${tenant_namespace}
   pipeline:
+    maxRetries: 0
     pipelineRef:
       params:
         - name: url

--- a/integration-tests/rh-push-helm-chart-to-registry-redhat-io/resources/managed/rpa.yaml
+++ b/integration-tests/rh-push-helm-chart-to-registry-redhat-io/resources/managed/rpa.yaml
@@ -38,6 +38,7 @@ spec:
         ref: 'master'
   origin: ${tenant_namespace}
   pipeline:
+    maxRetries: 0
     pipelineRef:
       params:
         - name: url

--- a/integration-tests/rh-push-to-external-registry-multi-component/resources/managed/rpa.yaml
+++ b/integration-tests/rh-push-to-external-registry-multi-component/resources/managed/rpa.yaml
@@ -36,6 +36,7 @@ spec:
         ref: 'master'
   origin: ${tenant_namespace}
   pipeline:
+    maxRetries: 0
     pipelineRef:
       params:
         - name: url

--- a/integration-tests/rh-push-to-external-registry/resources/managed/rpa.yaml
+++ b/integration-tests/rh-push-to-external-registry/resources/managed/rpa.yaml
@@ -33,6 +33,7 @@ spec:
         ref: 'master'
   origin: ${tenant_namespace}
   pipeline:
+    maxRetries: 0
     pipelineRef:
       params:
         - name: url

--- a/integration-tests/rh-push-to-registry-redhat-io/resources/managed/rpa.yaml
+++ b/integration-tests/rh-push-to-registry-redhat-io/resources/managed/rpa.yaml
@@ -36,6 +36,7 @@ spec:
         ref: 'master'
   origin: ${tenant_namespace}
   pipeline:
+    maxRetries: 0
     pipelineRef:
       params:
         - name: url

--- a/integration-tests/rhtap-service-push/resources/managed/rpa.yaml
+++ b/integration-tests/rhtap-service-push/resources/managed/rpa.yaml
@@ -30,6 +30,7 @@ spec:
       prCreatorSecret: infra-pr-creator-${component_name}
   origin: ${tenant_namespace}
   pipeline:
+    maxRetries: 0
     pipelineRef:
       params:
         - name: url


### PR DESCRIPTION
## Describe your changes
E2E tests should succeed on first run. Automatic retries are enabled in ReleaseServiceConfig for pipelines, but we need to override with maxRetries: 0 for e2e RPAs so tests fail and not retry.

## Relevant Jira
https://redhat.atlassian.net/browse/RELEASE-2116

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
