### PR TITLE
chore: bump apply-mapping images for custom tag support

### DIFF
--- a/tasks/managed/apply-mapping/README.md
+++ b/tasks/managed/apply-mapping/README.md
@@ -28,6 +28,9 @@ This task supports variable expansion in tag values from the mapping. The curren
   both will receive v1.0.0-6).
 * "{{ oci_version }}" -> The version from OCI image annotations (org.opencontainers.image.version), with fallback
   to OCI image labels if not present in annotations (converts + to _ for tag compliance)
+* "{{ labels.konflux.additional-tags }}" -> Build lets a Containerfile have extra tags via
+  LABEL (konflux.additional-tags="tag1 tag2"); expands to one tag per space and/or comma
+  separated value.
 
 You can also expand image labels, e.g. "{{ labels.mylabel }}" -> The value of image label "mylabel"
 

--- a/tasks/managed/apply-mapping/apply-mapping.yaml
+++ b/tasks/managed/apply-mapping/apply-mapping.yaml
@@ -36,6 +36,9 @@ spec:
       both will receive v1.0.0-6).
     * "{{ oci_version }}" -> The version from OCI image annotations (org.opencontainers.image.version), with fallback
       to OCI image labels if not present in annotations (converts + to _ for tag compliance)
+    * "{{ labels.konflux.additional-tags }}" -> Build lets a Containerfile have extra tags via
+      LABEL (konflux.additional-tags="tag1 tag2"); expands to one tag per space and/or comma
+      separated value.
 
     You can also expand image labels, e.g. "{{ labels.mylabel }}" -> The value of image label "mylabel"
   params:
@@ -157,7 +160,7 @@ spec:
         - name: caCertPath
           value: $(params.caCertPath)
     - name: apply-mapping
-      image: quay.io/konflux-ci/release-service-utils@sha256:3b984946b82cf63d5595e3ba2cc38b4232f3c7293a3d9b774434d15f8c4b087c
+      image: quay.io/konflux-ci/release-service-utils@sha256:d84bb7da0988c3cbce65ed714beddda4694b9e3201af56a135ac5843a05abe1e
       computeResources:
         limits:
           memory: 128Mi

--- a/tasks/managed/apply-mapping/tests/test-apply-mapping.yaml
+++ b/tasks/managed/apply-mapping/tests/test-apply-mapping.yaml
@@ -49,7 +49,7 @@ spec:
               value: "$(params.trustedArtifactsDebug)"
         steps:
           - name: setup-values
-            image: quay.io/konflux-ci/release-service-utils@sha256:3b984946b82cf63d5595e3ba2cc38b4232f3c7293a3d9b774434d15f8c4b087c
+            image: quay.io/konflux-ci/release-service-utils@sha256:d84bb7da0988c3cbce65ed714beddda4694b9e3201af56a135ac5843a05abe1e
             script: |
               #!/usr/bin/env sh
               set -eux
@@ -199,7 +199,7 @@ spec:
               - name: sourceDataArtifact
                 value: $(params.sourceDataArtifact)
           - name: check-result
-            image: quay.io/konflux-ci/release-service-utils@sha256:3b984946b82cf63d5595e3ba2cc38b4232f3c7293a3d9b774434d15f8c4b087c
+            image: quay.io/konflux-ci/release-service-utils@sha256:d84bb7da0988c3cbce65ed714beddda4694b9e3201af56a135ac5843a05abe1e
             script: |
               #!/usr/bin/env bash
               set -eux


### PR DESCRIPTION

## Describe your changes
Update apply-mapping image references in the catalog to pick up support for  {{ labels.konflux.additional-tags }}

Build lets a Containerfile have extra tags via
LABEL konflux.additional-tags="tag1 tag2" or "tag1, tag2". Expands to one tag per space and/or comma separated value. Raises if the label is absent, empty or a tag is invalid.

Reference: release-service-utils/pull/1006

https://konflux.pages.redhat.com/docs/users/building/custom-tags.html

## Relevant Jira
Depends on: https://github.com/konflux-ci/release-service-utils/pull/1006
Jira: https://redhat.atlassian.net/browse/KONFLUX-14437
## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
