### PR TITLE
fix: signtool use cert thumbprint sha

### DIFF
--- a/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
+++ b/tasks/internal/push-artifacts-to-cdn-task/push-artifacts-to-cdn-task.yaml
@@ -179,7 +179,7 @@ spec:
 
   steps:
     - name: push-artifacts-to-cdn
-      image: quay.io/konflux-ci/release-service-utils@sha256:2ae61d5886887b230860934bfc7719453e44bc8882fab5ad84a483a720c5763d
+      image: quay.io/redhat-user-workloads/rhtap-release-2-tenant/release-service-utils-standalone@sha256:e8e99192a75e7bb3f56a66e6a717ed7eaecf90af99b00580bcfffd7f45d99ce8
       securityContext:
         runAsUser: 1001
       computeResources:


### PR DESCRIPTION
Using the subject was error prone.
This is from release-service-utils PR 1017

Assisted-by: Cursor AI

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [ ] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
