### PR TITLE
fix(RHELWF-14561): increase memory for large RPM downloads

### DIFF
--- a/tasks/managed/push-rpm-to-koji/push-rpm-to-koji.yaml
+++ b/tasks/managed/push-rpm-to-koji/push-rpm-to-koji.yaml
@@ -127,9 +127,9 @@ spec:
       image: "$(params.pipelineImage)"
       computeResources:
         limits:
-          memory: 256Mi
+          memory: 3Gi
         requests:
-          memory: 256Mi
+          memory: 3Gi
           cpu: 325m
       env:
         - name: SNAPSHOT_SPEC_FILE
@@ -149,6 +149,8 @@ spec:
             echo "No data JSON was provided."
             exit 1
         fi
+
+        RPM_DOWNLOAD_DIR="/var/workdir/rpm-extract"
 
         COMPONENT_GROUP=$(jq -r '.componentGroup' "${SNAPSHOT_SPEC_FILE}")
         NUM_COMPONENTS=$(jq '.components | length' "${SNAPSHOT_SPEC_FILE}")
@@ -236,7 +238,8 @@ spec:
               continue
           fi
 
-          mkdir temp && cd temp
+          mkdir -p "$RPM_DOWNLOAD_DIR"
+          pushd "$RPM_DOWNLOAD_DIR" > /dev/null
 
           # The login serviceaccount should have the dockerconfig to pull the images.
           # oras has very limited support for selecting the right auth entry,
@@ -251,7 +254,8 @@ spec:
           if [[ "$KOJI_IMPORT_DRAFT" == "false" ]]; then
               if koji-cmd buildinfo "$PACKAGE_NVR" >/dev/null 2>&1;  then
                   printf "Skip import %s into BREW as it's exist ...\n" "$PACKAGE_NVR"
-                  cd .. && rm -rf temp
+                  popd > /dev/null
+                  rm -rf "$RPM_DOWNLOAD_DIR"
                   continue
               fi
               draft="false"
@@ -322,7 +326,8 @@ spec:
           done
 
           # Clean up to handle next component
-          cd .. && rm -rf temp
+          popd > /dev/null
+          rm -rf "$RPM_DOWNLOAD_DIR"
         done
 
         printf 'Completed "%s" for "%s"\n\n' "$(context.task.name)" "$COMPONENT_GROUP"


### PR DESCRIPTION
The task was OOMKilled when downloading large RPMs (Firefox, kernel) because the emptyDir volume is tmpfs-backed. Increased memory from 256Mi to 3Gi following the proven solution from push-rpms-to-pulp (commit d05a8042).

Changed download directory from scattered temp dirs to explicit /var/workdir/rpm-extract path. This is a temporary location that won't conflict with task data and is created/removed per component. Uses pushd/popd for navigation per project conventions.

Assisted-by: Claude Sonnet 4.5

## Describe your changes

## Relevant Jira

RHELWF-14561
OSCI-10480

## Checklist before requesting a review
- [x] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [x] My commit message includes `Signed-off-by: My name <email>`
- [x] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)
- [ ] I have run the README.md generator script in `.github/scripts/readme_generator.sh` and verified the results using `.github/scripts/check_readme.sh`
- [x] If an AI agent was used, I marked that via a commit footer like `Assisted-By: Cursor`
